### PR TITLE
chore(hysteria2): fix for uri and shadowrocket obfs

### DIFF
--- a/backend/src/core/proxy-utils/producers/shadowrocket.js
+++ b/backend/src/core/proxy-utils/producers/shadowrocket.js
@@ -81,6 +81,24 @@ export default function ShadowRocket_Producer() {
                         ) {
                             proxy['fast-open'] = proxy.tfo;
                         }
+                    } else if (proxy.type === 'hysteria2') {
+                        if (
+                            proxy['obfs-password'] &&
+                            proxy.obfs == 'salamander') {
+                            proxy.obfs = proxy['obfs-password'];
+                            delete proxy['obfs-password'];
+                        }
+                        if (isPresent(proxy, 'alpn')) {
+                            proxy.alpn = Array.isArray(proxy.alpn)
+                                ? proxy.alpn
+                                : [proxy.alpn];
+                        }
+                        if (
+                            isPresent(proxy, 'tfo') &&
+                            !isPresent(proxy, 'fast-open')
+                        ) {
+                            proxy['fast-open'] = proxy.tfo;
+                        }
                     } else if (proxy.type === 'wireguard') {
                         proxy.keepalive =
                             proxy.keepalive ?? proxy['persistent-keepalive'];

--- a/backend/src/core/proxy-utils/producers/uri.js
+++ b/backend/src/core/proxy-utils/producers/uri.js
@@ -249,6 +249,9 @@ export default function URI_Producer() {
                         `pinSHA256=${encodeURIComponent(proxy['tls-fingerprint'])}`,
                     );
                 }
+                if (proxy.tfo) {
+                    hysteria2params.push(`fastopen=1`);
+                }
                 result = `hysteria2://${proxy.password}@${proxy.server}:${
                     proxy.port
                 }?${hysteria2params.join('&')}#${encodeURIComponent(

--- a/backend/src/core/proxy-utils/producers/uri.js
+++ b/backend/src/core/proxy-utils/producers/uri.js
@@ -244,9 +244,9 @@ export default function URI_Producer() {
                         `sni=${encodeURIComponent(proxy.sni)}`,
                     );
                 }
-                if (proxy.fingerprint) {
+                if (proxy['tls-fingerprint']) {
                     hysteria2params.push(
-                        `pinSHA256=${encodeURIComponent(proxy.fingerprint)}`,
+                        `pinSHA256=${encodeURIComponent(proxy['tls-fingerprint'])}`,
                     );
                 }
                 result = `hysteria2://${proxy.password}@${proxy.server}:${


### PR DESCRIPTION
[fix(hysteria2): Change to TLS Fingerprint](https://github.com/Ariesly/Sub-Store/commit/fe937d6ebfcf7a57f5834636f537940bb6a7662d)
[chore(hysteria2): Uri support with tfo](https://github.com/Ariesly/Sub-Store/commit/e7dfa1ce38d97ca147c4ff351ae4d7c91fefc0da)
[fix(hysteria2): For shadowrocket obfs](https://github.com/Ariesly/Sub-Store/commit/0d8fa91cd5f5cc1d95b413a500e2027f7f6e2265)