### PR TITLE
fix: Handles node-info IPv6 address URIs

### DIFF
--- a/backend/src/restful/node-info.js
+++ b/backend/src/restful/node-info.js
@@ -22,7 +22,10 @@ async function getNodeInfo(req, res) {
         const info = await $http
             .get({
                 url: `http://ip-api.com/json/${encodeURIComponent(
-                    proxy.server,
+                    proxy.server
+                        .trim()
+                        .replace(/^\[/, '')
+                        .replace(/\]$/, '')
                 )}?lang=${lang}`,
                 headers: {
                     'User-Agent':


### PR DESCRIPTION
URI_Producer `proxy.server` will be modified here, causing ipv6 unable to get IP API info well.


[/backend/src/core/proxy-utils/producers/uri.js#L10](https://github.com/sub-store-org/Sub-Store/blob/c2bd80207a57f4acbfc1eed818a59e0117149046/backend/src/core/proxy-utils/producers/uri.js#L10)