### PR TITLE
修复clash规则头部有注释的情况下规则转换功能失败的问题

### DIFF
--- a/backend/src/core/rule-utils/preprocessors.js
+++ b/backend/src/core/rule-utils/preprocessors.js
@@ -8,7 +8,7 @@ function HTML() {
 
 function ClashProvider() {
     const name = 'Clash Provider';
-    const test = (raw) => raw.indexOf('payload:') === 0;
+    const test = (raw) => /^payload:/gm.exec(raw).index >= 0;
     const parse = (raw) => {
         return raw.replace('payload:', '').replace(/^\s*-\s*/gm, '');
     };


### PR DESCRIPTION
通常情况下，clash的规则头部的第一行不是payload，而是各种注释，在头部有注释的情况下，规则预处理test会失效，进而导致规则转换失败；本次提交修复判断payload的位置，进而通过测试，预处理操作才能执行。