### PR TITLE
fix: 流量信息匹配错误

### DIFF
--- a/backend/src/utils/flow.js
+++ b/backend/src/utils/flow.js
@@ -88,13 +88,13 @@ export async function getFlowHeaders(rawUrl, ua, timeout) {
 export function parseFlowHeaders(flowHeaders) {
     if (!flowHeaders) return;
     // unit is KB
-    const uploadMatch = flowHeaders.match(/upload=(-?)(\d+)/);
+    const uploadMatch = flowHeaders.match(/upload=(-?)([E+.\d]+)/);
     const upload = Number(uploadMatch[1] + uploadMatch[2]);
 
-    const downloadMatch = flowHeaders.match(/download=(-?)(\d+)/);
+    const downloadMatch = flowHeaders.match(/download=(-?)([E+.\d]+)/);
     const download = Number(downloadMatch[1] + downloadMatch[2]);
 
-    const total = Number(flowHeaders.match(/total=(\d+)/)[1]);
+    const total = Number(flowHeaders.match(/total=([E+.\d]+)/)[1]);
 
     // optional expire timestamp
     const match = flowHeaders.match(/expire=(\d+)/);


### PR DESCRIPTION
在无限流量机场的订阅中，维护者一般会给一个特别大的流量限制。SSPanel中，此时下发的 `Subscription-Userinfo` 会使用科学计数法，例如：

```bash
> curl -i https://…
HTTP/1.1 200 OK
Server: nginx
Date: Sat, 20 Jan 2024 04:55:39 GMT
Content-Type: application/octet-stream; charset=utf-8
Content-Length: 24116
Connection: keep-alive
Cache-Control: no-store, no-cache, must-revalidate
Content-Disposition: attachment; filename=UndefinedNode_1705726573.txt
Subscription-Userinfo: upload=153123226490; download=3327891037203; total=1.0737407502582E+15; expire=1713631253
Strict-Transport-Security: max-age=31536000
Cache-Control: no-cache
```

此时，`total=1.0737407502582E+15` 在Sub-Store中仅能匹配到前面的数字，导致UI界面显示总流量为1字节，如下图：

![IMG_0561](https://github.com/sub-store-org/Sub-Store/assets/54678581/d687cc57-9c12-4520-adca-c4845d6f5799)

解决方法是匹配科学计数法的 `E+.` 这三个字符，然后由JS的Number直接识别并转换。