### PR TITLE
修复IP-CIDR的option错误

### DIFF
--- a/backend/src/core/rule-utils/parsers.js
+++ b/backend/src/core/rule-utils/parsers.js
@@ -9,7 +9,7 @@ const RULE_TYPES_MAPPING = [
     [/^(IN|SRC)-PORT$/, 'IN-PORT'],
     [/^PROTOCOL$/, 'PROTOCOL'],
     [/^IP-CIDR$/i, 'IP-CIDR'],
-    [/^(IP-CIDR6|ip6-cidr|IP6-CIDR)$/],
+    [/^(IP-CIDR6|ip6-cidr|IP6-CIDR)$/, 'IP-CIDR6'],
 ];
 
 function AllRuleParser() {
@@ -40,7 +40,7 @@ function AllRuleParser() {
                             rule.type === 'IP-CIDR' ||
                             rule.type === 'IP-CIDR6'
                         ) {
-                            rule.options = params.slice(2);
+                            rule.options = params.slice(2).join(",");
                         }
                         result.push(rule);
                     }

--- a/backend/src/core/rule-utils/producers.js
+++ b/backend/src/core/rule-utils/producers.js
@@ -31,7 +31,7 @@ function SurgeRuleSet() {
     const func = (rule) => {
         let output = `${rule.type},${rule.content}`;
         if (rule.type === 'IP-CIDR' || rule.type === 'IP-CIDR6') {
-            output += rule.options ? `,${rule.options[0]}` : '';
+            output += rule.options ? `,${rule.options}` : '';
         }
         return output;
     };
@@ -63,7 +63,7 @@ function ClashRuleProvider() {
                     rule.content
                 }`;
                 if (rule.type === 'IP-CIDR' || rule.type === 'IP-CIDR6') {
-                    output += rule.options ? `,${rule.options[0]}` : '';
+                    output += rule.options ? `,${rule.options}` : '';
                 }
                 return output;
             }),


### PR DESCRIPTION

例子：
```
IP-CIDR,99.80.88.0/25,no-resolve
IP-CIDR6,2607:fb10::/32,no-resolve
IP-CIDR6,2620:10c:7000::/44,no-resolve
IP-CIDR6,2a00:86c0::/32,no-resolve
IP-CIDR6,2a03:5640::/32,no-resolve
```
转换出错误结果
```
  - 'IP-CIDR,99.80.88.0/25,no-resolve'
  - 'undefined,2607:fb10::/32'
  - 'undefined,2620:10c:7000::/44'
  - 'undefined,2a00:86c0::/32'
  - 'undefined,2a03:5640::/32'
```

本次提交修复了这个错误
```
  - 'IP-CIDR,99.80.34.64/26,no-resolve'
  - 'IP-CIDR,99.80.88.0/25,no-resolve'
  - 'IP-CIDR6,2607:fb10::/32,no-resolve'
  - 'IP-CIDR6,2620:10c:7000::/44,no-resolve'
  - 'IP-CIDR6,2a00:86c0::/32,no-resolve'
  - 'IP-CIDR6,2a03:5640::/32,no-resolve'
```

