### PR TITLE
[Feat]规则转换增加对GEOIP与GEOSITE的支持

### DIFF
--- a/backend/src/core/rule-utils/parsers.js
+++ b/backend/src/core/rule-utils/parsers.js
@@ -10,6 +10,8 @@ const RULE_TYPES_MAPPING = [
     [/^PROTOCOL$/, 'PROTOCOL'],
     [/^IP-CIDR$/i, 'IP-CIDR'],
     [/^(IP-CIDR6|ip6-cidr|IP6-CIDR)$/, 'IP-CIDR6'],
+    [/^GEOIP$/i, 'GEOIP'],
+    [/^GEOSITE$/i, 'GEOSITE'],
 ];
 
 function AllRuleParser() {


### PR DESCRIPTION
规则转换功能目前不支持GEOIP与GEOSITE，暂时不清楚时为什么，遂提交本次request增加对这两种规则的支持。