### PR TITLE
fix: clash 配置中 VLESS 节点的 short-id 值被错误解析

### DIFF
--- a/backend/src/core/proxy-utils/preprocessors/index.js
+++ b/backend/src/core/proxy-utils/preprocessors/index.js
@@ -50,10 +50,32 @@ function Clash() {
     };
     const parse = function (raw) {
         // Clash YAML format
+
+        // 防止 VLESS节点 reality-opts 选项中的 short-id 被解析成 Infinity
+        // 匹配 short-id 冒号后面的值(包含空格和引号)
+        const afterReplace = raw.replace(
+            /short-id:([ ]*[^,\n}]*)/g,
+            (matched, value) => {
+            const afterTrim = value.trim();
+        
+            // 为空
+            if (!afterTrim || afterTrim === '') {
+                return 'short-id: ""'
+            }
+        
+            // 是否被引号包裹
+            if (/^(['"]).*\1$/.test(afterTrim)) {
+                return `short-id: ${afterTrim}`;
+            } else {
+                return `short-id: "${afterTrim}"`
+            }
+            }
+        );
+
         const {
             proxies,
             'global-client-fingerprint': globalClientFingerprint,
-        } = safeLoad(raw);
+        } = safeLoad(afterReplace);
         return proxies
             .map((p) => {
                 // https://github.com/MetaCubeX/mihomo/blob/Alpha/docs/config.yaml#L73C1-L73C26


### PR DESCRIPTION
根据官方文档，[short-id](https://xtls.github.io/config/transport.html#realityobject:~:text=%E5%90%8C%20TLSObject%E3%80%82-,shortId,-%3A%20string) 为字符串类型。当 VLESS 节点中的 reality-opts 的 `short-id` 值**未被引号包裹**时，会导致 js-yaml 将**以数字开头**的值作为数字解析，从而可能解析出 Infinity -- null。而该结果会导致 clash 内核**崩溃**。
<img width="1179" alt="SCR-20241011-qwtf" src="https://github.com/user-attachments/assets/ab4cdaee-8238-4519-a312-8747b129c536">
```plantxt
github.com/metacubex/mihomo/component/resource/fetcher.go:178 +0xca
created by github.com/metacubex/mihomo/component/resource.(*Fetcher[...]).startPullLoop in goroutine 90
	github.com/metacubex/mihomo/component/resource/fetcher.go:146 +0xfe
github.com/metacubex/mihomo/component/resource.(*Fetcher[...]).pullLoop(0x15f2760, 0x1)
	github.com/metacubex/mihomo/component/resource/fetcher.go:188 +0x25
github.com/metacubex/mihomo/component/resource.(*Fetcher[...]).updateWithLog(0x7)
	github.com/metacubex/mihomo/component/resource/fetcher.go:89 +0xf5
github.com/metacubex/mihomo/component/resource.(*Fetcher[...]).Update(0x15f2760)
	github.com/metacubex/mihomo/component/resource/fetcher.go:110 +0x16e
github.com/metacubex/mihomo/component/resource.(*Fetcher[...]).loadBuf(0x15f2760, {0xc003fd2000, 0x1173c, 0x12000}, {{0xed, 0x24, 0x42, 0xff, 0x9b, 0x4e, ...}}, ...)
	github.com/metacubex/mihomo/adapter/provider/provider.go:417 +0xbff
github.com/metacubex/mihomo/adapter/provider.NewProxySetProvider.proxiesParseAndFilter.func1({0xc003fd2000, 0x1173c, 0x12000})
	github.com/metacubex/mihomo/adapter/parser.go:69 +0x870
github.com/metacubex/mihomo/adapter.ParseProxy(0xc00387d230)
	github.com/metacubex/mihomo/common/structure/structure.go:81 +0x573
github.com/metacubex/mihomo/common/structure.(*Decoder).Decode(0xc0042219a0, 0xc00387d230, {0x112c280, 0xc002aed2c0})
	github.com/metacubex/mihomo/common/structure/structure.go:121 +0x258
github.com/metacubex/mihomo/common/structure.(*Decoder).decode(0xc0042219a0, {0x111c166, 0xc}, {0x11b3f80, 0xc00387d260}, {0x1262120?, 0xc002aed390?, 0x1e?})
	github.com/metacubex/mihomo/common/structure/structure.go:412 +0x286
github.com/metacubex/mihomo/common/structure.(*Decoder).decodeStruct(0xc0042219a0, {0x111c166, 0xc}, {0x11b3f80?, 0xc00387d260?}, {0x1262120?, 0xc002aed390?, 0x111c165?})
	github.com/metacubex/mihomo/common/structure/structure.go:546 +0xb10
github.com/metacubex/mihomo/common/structure.(*Decoder).decodeStructFromMap(0xc0042219a0, {0x111c166, 0xc}, {0x11b3f80?, 0xc00387d260?, 0x47310a?}, {0x1262120?, 0xc002aed390?, 0x13a2c00?})
	github.com/metacubex/mihomo/common/structure/structure.go:111 +0x29a
github.com/metacubex/mihomo/common/structure.(*Decoder).decode(0xc0042219a0, {0xc0034c4420, 0x15}, {0x0, 0x0}, {0x115d600?, 0xc002aed3a0?, 0x10?})
	github.com/metacubex/mihomo/common/structure/structure.go:251 +0x336
github.com/metacubex/mihomo/common/structure.(*Decoder).decodeString(0xc0042219a0?, {0xc0034c4420, 0x15}, {0x0?, 0x0?}, {0x115d600?, 0xc002aed3a0?, 0x4ca850?})
reflect.Value.Type(...)
reflect.Value.typeSlow({0x0?, 0x0?, 0xc00421fbd0?})
goroutine 683 [running]:
panic: reflect: call of reflect.Value.Type on zero Value
```
---

该 fix 在 safeload clash 配置前，将 `short-id` 的值**用引号包裹**，防止解析错误。