### PR TITLE
fix: remove quotes from Loon shadow-tls password

### DIFF
--- a/backend/src/core/proxy-utils/producers/loon.js
+++ b/backend/src/core/proxy-utils/producers/loon.js
@@ -158,7 +158,7 @@ function shadowsocks(proxy) {
 
     // shadow-tls
     if (isPresent(proxy, 'shadow-tls-password')) {
-        result.append(`,shadow-tls-password="${proxy['shadow-tls-password']}"`);
+        result.append(`,shadow-tls-password=${proxy['shadow-tls-password']}`);
 
         result.appendIfPresent(
             `,shadow-tls-version=${proxy['shadow-tls-version']}`,
@@ -175,7 +175,7 @@ function shadowsocks(proxy) {
         const host = proxy['plugin-opts'].host;
         const version = proxy['plugin-opts'].version;
         if (password) {
-            result.append(`,shadow-tls-password="${password}"`);
+            result.append(`,shadow-tls-password=${password}`);
             if (host) {
                 result.append(`,shadow-tls-sni=${host}`);
             }
@@ -252,7 +252,7 @@ function shadowsocksr(proxy) {
 
     // shadow-tls
     if (isPresent(proxy, 'shadow-tls-password')) {
-        result.append(`,shadow-tls-password="${proxy['shadow-tls-password']}"`);
+        result.append(`,shadow-tls-password=${proxy['shadow-tls-password']}`);
 
         result.appendIfPresent(
             `,shadow-tls-version=${proxy['shadow-tls-version']}`,
@@ -269,7 +269,7 @@ function shadowsocksr(proxy) {
         const host = proxy['plugin-opts'].host;
         const version = proxy['plugin-opts'].version;
         if (password) {
-            result.append(`,shadow-tls-password="${password}"`);
+            result.append(`,shadow-tls-password=${password}`);
             if (host) {
                 result.append(`,shadow-tls-sni=${host}`);
             }

--- a/backend/src/test/proxy-producers/text.spec.js
+++ b/backend/src/test/proxy-producers/text.spec.js
@@ -433,6 +433,44 @@ describe('Proxy text producers', function () {
         );
     });
 
+    it('produces Loon Shadowsocks Shadow TLS passwords without quotes', function () {
+        const output = produceExternal('Loon', [
+            {
+                type: 'ss',
+                name: 'Loon SS ShadowTLS Fields',
+                server: 'ss.example.com',
+                port: 8388,
+                cipher: 'chacha20-ietf-poly1305',
+                password: 'ss-pass',
+                'shadow-tls-password': 'dzUjK3l+mXO/xxx=',
+                'shadow-tls-sni': 'p11.douyinpic.com',
+                'shadow-tls-version': 3,
+                udp: true,
+            },
+            {
+                type: 'ss',
+                name: 'Loon SS ShadowTLS Plugin',
+                server: 'ss-plugin.example.com',
+                port: 8388,
+                cipher: 'chacha20-ietf-poly1305',
+                password: 'ss-pass',
+                plugin: 'shadow-tls',
+                'plugin-opts': {
+                    password: 'plugin-shadow-pass',
+                    host: 'mask.example.com',
+                    version: 3,
+                },
+            },
+        ]);
+
+        expect(output).to.equal(
+            [
+                'Loon SS ShadowTLS Fields=shadowsocks,ss.example.com,8388,chacha20-ietf-poly1305,"ss-pass",shadow-tls-password=dzUjK3l+mXO/xxx=,shadow-tls-version=3,shadow-tls-sni=p11.douyinpic.com,udp=true',
+                'Loon SS ShadowTLS Plugin=shadowsocks,ss-plugin.example.com,8388,chacha20-ietf-poly1305,"ss-pass",shadow-tls-password=plugin-shadow-pass,shadow-tls-sni=mask.example.com,shadow-tls-version=3',
+            ].join('\n'),
+        );
+    });
+
     it('emits Loon tls-profile and alpn for TLS protocol outputs', function () {
         const alpn = ['http/1.1', 'h2', 'h3'];
         const output = produceExternal('Loon', [


### PR DESCRIPTION
Loon 开发者确认目前版本携带引号会出问题：‘shadow-tls-password 中的双引号去掉就可以了’