### PR TITLE
feat(SurgeMac): expose mihomoLocalPort via URL query

### DIFF
--- a/backend/src/restful/download.js
+++ b/backend/src/restful/download.js
@@ -42,12 +42,20 @@ function getMihomoExternalOptions(query) {
     const mihomoMergeName = useMihomoExternal
         ? query.mihomoMergeName
         : undefined;
+    let mihomoLocalPort;
+    if (useMihomoExternal && query.mihomoLocalPort != null) {
+        const parsed = parseInt(query.mihomoLocalPort, 10);
+        if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535) {
+            mihomoLocalPort = parsed;
+        }
+    }
 
     return {
         useMihomoExternal,
         mihomoExternal,
         mihomoMerge,
         mihomoMergeName,
+        mihomoLocalPort,
     };
 }
 
@@ -126,8 +134,13 @@ async function downloadSubscription(req, res) {
     let { name, nezhaIndex } = req.params;
     const isShareRoute = req.path?.startsWith('/share/');
 
-    const { useMihomoExternal, mihomoMerge, mihomoMergeName, mihomoExternal } =
-        getMihomoExternalOptions(req.query);
+    const {
+        useMihomoExternal,
+        mihomoMerge,
+        mihomoMergeName,
+        mihomoExternal,
+        mihomoLocalPort,
+    } = getMihomoExternalOptions(req.query);
 
     const platform =
         req.query.platform ||
@@ -316,6 +329,7 @@ async function downloadSubscription(req, res) {
                     merge: mihomoMerge,
                     mergeName: mihomoMergeName,
                     mihomoExternal,
+                    localPort: mihomoLocalPort,
                     prettyYaml,
                 },
                 $options,
@@ -533,8 +547,13 @@ async function downloadSubscription(req, res) {
 async function downloadCollection(req, res) {
     let { name, nezhaIndex } = req.params;
 
-    const { useMihomoExternal, mihomoMerge, mihomoMergeName, mihomoExternal } =
-        getMihomoExternalOptions(req.query);
+    const {
+        useMihomoExternal,
+        mihomoMerge,
+        mihomoMergeName,
+        mihomoExternal,
+        mihomoLocalPort,
+    } = getMihomoExternalOptions(req.query);
 
     const platform =
         req.query.platform ||
@@ -640,6 +659,7 @@ async function downloadCollection(req, res) {
                     merge: mihomoMerge,
                     mergeName: mihomoMergeName,
                     mihomoExternal,
+                    localPort: mihomoLocalPort,
                     prettyYaml,
                 },
                 $options,


### PR DESCRIPTION
## Motivation

Follow-up to #588; full write-up in #600.

In merge mode, `producers/surgemac.js` allocates local SOCKS5 listener ports from `65535` downward, per download:

https://github.com/sub-store-org/Sub-Store/blob/master/backend/src/core/proxy-utils/producers/surgemac.js#L142

```js
let localPort = opts?.localPort || proxy._localPort || 65535;
```

Two SurgeMac merge subscriptions therefore get overlapping port ranges near 65535. Surge runs one mihomo core per subscription; the cores race to `bind()` the same `127.0.0.1` ports, and the loser's SOCKS5 policies are silently served by the winner's nodes (cross-subscription). In my setup a low-rate-looking policy collided onto a `5.0x` node and an Emby stream was billed at 5× (~7 GB → ~34.8 GB). Details in #600.

There is no per-subscription way to offset the start port via URL today: `download.js` forwards `mihomoExternal` / `mihomoMerge` / `mihomoMergeName` but not `localPort`, and `$options` is not merged into `produceOpts`. The only knob is the per-node `_localPort`, impractical for large subscriptions.

## Change

`producers/surgemac.js` already reads `opts.localPort` (L142), so the producer is untouched. This PR only plumbs it from the query in both download handlers, mirroring `mihomoMerge` / `mihomoMergeName`:

- parse `mihomoLocalPort` (validated `1–65535`) in `getMihomoExternalOptions`
- pass it through `produceOpts.localPort` in `downloadSubscription` and `downloadCollection`

## Usage

```
/download/subA?target=SurgeMac&mihomoMerge=...&mihomoLocalPort=65535
/download/subB?target=SurgeMac&mihomoMerge=...&mihomoLocalPort=65000
```

## Compatibility

No behaviour change when `mihomoLocalPort` is absent (still defaults to `65535`). Invalid values (non-integer / out of range) are ignored and fall back to the default.

Closes #600
