### PR TITLE
feat: add new raw option for script/filter operation

### DIFF
--- a/backend/src/core/proxy-utils/index.js
+++ b/backend/src/core/proxy-utils/index.js
@@ -33,7 +33,6 @@ import { produceArtifact } from '@/restful/sync';
 import { getFlag, removeFlag, getISO, MMDB } from '@/utils/geo';
 import Gist from '@/utils/gist';
 import {
-    isPresent,
     isShadowsocksOverTls,
     normalizeWireGuardInterface,
 } from './producers/utils';
@@ -141,6 +140,7 @@ async function processFn(
     targetPlatform,
     source,
     $options,
+    raw,
 ) {
     let context = {};
     for (const item of operators) {
@@ -198,6 +198,7 @@ async function processFn(
                 source,
                 $options,
                 context,
+                raw,
             );
         } else {
             processor = PROXY_PROCESSORS[item.type](item.args || {});
@@ -418,7 +419,11 @@ function produce(proxies, targetPlatform, type, opts = {}) {
             !supportsRootProxyHeaders(proxy, targetPlatform)
         ) {
             $.error(
-                `Target platform ${targetPlatform} does not support headers for ${getRootHeaderProxyLabel(proxy)} proxy ${proxy.name || `${proxy.server}:${proxy.port}`}. Proxy has been filtered.`,
+                `Target platform ${targetPlatform} does not support headers for ${getRootHeaderProxyLabel(
+                    proxy,
+                )} proxy ${
+                    proxy.name || `${proxy.server}:${proxy.port}`
+                }. Proxy has been filtered.`,
             );
             return false;
         }
@@ -616,9 +621,7 @@ function supportsRootProxyHeaders(proxy, targetPlatform) {
     }
 
     if (
-        ['clashmeta', 'clash.meta', 'meta', 'mihomo'].includes(
-            normalizedTarget,
-        )
+        ['clashmeta', 'clash.meta', 'meta', 'mihomo'].includes(normalizedTarget)
     ) {
         return proxy.type === 'http';
     }

--- a/backend/src/core/proxy-utils/processors/index.js
+++ b/backend/src/core/proxy-utils/processors/index.js
@@ -428,6 +428,7 @@ function ScriptOperator(
     source,
     $options,
     context,
+    raw,
 ) {
     context.source = source;
     context.env = env;
@@ -464,7 +465,7 @@ function ScriptOperator(
                     $arguments,
                     $options,
                 );
-                output = operator(proxies, targetPlatform, context);
+                output = operator(proxies, targetPlatform, context, raw);
             })();
             return output;
         },
@@ -473,7 +474,7 @@ function ScriptOperator(
             await (async function () {
                 const operator = createDynamicFunction(
                     'operator',
-                    `async function operator(input = [], targetPlatform, context) {
+                    `async function operator(input = [], targetPlatform, context, raw) {
                         if (input && (input.$files || input.$content)) {
                             let { $content, $files, $options, $file } = input
                             if (['mihomoConfig', 'mihomoProfile'].includes($file?.type)) {
@@ -506,7 +507,7 @@ function ScriptOperator(
                     $arguments,
                     $options,
                 );
-                output = operator(proxies, targetPlatform, context);
+                output = operator(proxies, targetPlatform, context, raw);
             })();
             return output;
         },
@@ -1486,6 +1487,7 @@ function ScriptFilter(
     source,
     $options,
     context,
+    raw,
 ) {
     context.source = source;
     context.env = env;
@@ -1500,7 +1502,7 @@ function ScriptFilter(
                     $arguments,
                     $options,
                 );
-                output = filter(proxies, targetPlatform, context);
+                output = filter(proxies, targetPlatform, context, raw);
             })();
             return output;
         },
@@ -1509,7 +1511,7 @@ function ScriptFilter(
             await (async function () {
                 const filter = createDynamicFunction(
                     'filter',
-                    `async function filter(input = [], targetPlatform, context) {
+                    `async function filter(input = [], targetPlatform, context, raw) {
                         let proxies = input
                         let list = []
                         const fn = async ($server) => {
@@ -1523,7 +1525,7 @@ function ScriptFilter(
                     $arguments,
                     $options,
                 );
-                output = filter(proxies, targetPlatform, context);
+                output = filter(proxies, targetPlatform, context, raw);
             })();
             return output;
         },

--- a/backend/src/restful/preview.js
+++ b/backend/src/restful/preview.js
@@ -160,6 +160,8 @@ async function compareSub(req, res) {
             sub.process || [],
             target,
             { [sub.name]: sub },
+            undefined,
+            content,
         );
 
         // produce
@@ -312,6 +314,8 @@ async function compareCollection(req, res) {
                         sub.process || [],
                         'JSON',
                         { [sub.name]: sub, _collection: collection },
+                        undefined,
+                        raw,
                     );
                     results[name] = currentProxies;
                 } catch (err) {

--- a/backend/src/restful/sync.js
+++ b/backend/src/restful/sync.js
@@ -438,6 +438,7 @@ async function produceArtifact({
                 platform,
                 { [sub.name]: sub },
                 $options,
+                raw,
             );
             if (proxies.length === 0) {
                 throw new Error(`订阅 ${name} 中不含有效节点`);
@@ -627,6 +628,8 @@ async function produceArtifact({
                                 _collection: collection,
                                 $options,
                             },
+                            undefined,
+                            raw,
                         );
                         results[name] = currentProxies;
                         processed++;

--- a/backend/src/test/proxy-processors/process-context.spec.js
+++ b/backend/src/test/proxy-processors/process-context.spec.js
@@ -235,4 +235,59 @@ describe('Process context control', function () {
             'A-hello age-true',
         ]);
     });
+
+    it('passes raw source as the 4th argument to Script Operator', async function () {
+        const raw = ['raw-source-1', 'raw-source-2'];
+        const operators = [
+            {
+                type: 'Script Operator',
+                args: {
+                    mode: 'script',
+                    content: `function operator(proxies, targetPlatform, context, raw) {
+                        return proxies.map((proxy) => ({
+                            ...proxy,
+                            name: proxy.name + '-' + (Array.isArray(raw) ? raw.length : 'none'),
+                        }));
+                    }`,
+                },
+            },
+        ];
+
+        const output = await ProxyUtils.process(
+            [{ name: 'A' }],
+            operators,
+            'JSON',
+            undefined,
+            undefined,
+            raw,
+        );
+
+        expect(output.map((proxy) => proxy.name)).to.deep.equal(['A-2']);
+    });
+
+    it('passes raw source as the 4th argument to Script Filter', async function () {
+        const raw = ['only-source'];
+        const operators = [
+            {
+                type: 'Script Filter',
+                args: {
+                    mode: 'script',
+                    content: `function filter(proxies, targetPlatform, context, raw) {
+                        return proxies.map(() => Array.isArray(raw) && raw.length === 1);
+                    }`,
+                },
+            },
+        ];
+
+        const output = await ProxyUtils.process(
+            [{ name: 'A' }, { name: 'B' }],
+            operators,
+            'JSON',
+            undefined,
+            undefined,
+            raw,
+        );
+
+        expect(output.map((proxy) => proxy.name)).to.deep.equal(['A', 'B']);
+    });
 });

--- a/scripts/demo.js
+++ b/scripts/demo.js
@@ -1,4 +1,4 @@
-function operator(proxies = [], targetPlatform, context) {
+function operator(proxies = [], targetPlatform, context, raw) {
   // 支持快捷操作 不一定要写一个 function
   // 可参考 https://t.me/zhetengsha/970
   // https://t.me/zhetengsha/1009
@@ -455,6 +455,50 @@ function operator(proxies = [], targetPlatform, context) {
   //   "backend": "Node",
   //   "version": "2.14.198"
   // }
+
+  // raw 为传入的原始订阅内容(即解析成节点前, 从本地或远程获取到的整体文件内容)
+  // 仅在订阅/子订阅层的 脚本操作 和 脚本筛选 中提供, 组合订阅自身的脚本 及 文件处理 不提供(为 undefined)
+  // 数据形态: 单个本地源为字符串; 多个源(远程多链接, 或 mergeSources 为 localFirst/remoteFirst 合并模式)为字符串数组, 每项对应一个源
+  // 用途: 节点被解析后, 一些整体配置会丢失(解析只保留单个节点字段). 通过 raw 可从原始文件里读取这些信息
+  //      例如: 有些机场下发的 Clash/mihomo 配置里带有内部 DNS(dns.nameserver-policy), 这些不在单个节点里
+  // ⚠️ 注意: 快捷脚本(下面使用 $server 那种)里也可直接引用 raw 变量
+
+  // 示例: 从原始 Clash/mihomo 配置里取出 dns.nameserver-policy, 用其中的「域名通配」键判断节点 server 是否命中
+  // nameserver-policy 结构示例(值可能是字符串或数组):
+  //   '+.arpa': '10.0.0.1'          // 域名通配, 使用
+  //   'rule-set:cn': [ ... ]        // 带 `:`(rule-set:/geosite: 等), 本地无法判断域名集合, 跳过
+
+  // 1) 解析 raw, 取出 nameserver-policy (raw 可能是数组, 统一成数组处理)
+  // const rawList = Array.isArray(raw) ? raw : [raw]
+  // const policy = {}
+  // rawList.forEach((text) => {
+  //   if (typeof text !== 'string') return
+  //   let config
+  //   try { config = ProxyUtils.yaml.parse(text) } catch (e) { return }
+  //   Object.assign(policy, config?.dns?.['nameserver-policy'] || {})
+  // })
+
+  // 2) 只保留域名通配的键(键里没有 `:`, 即排除 rule-set:/geosite:/geoip: 等)
+  // const domainRules = Object.entries(policy).filter(([key]) => !key.includes(':'))
+
+  // 3) 后缀匹配: mihomo 域名通配 `+.arpa` 表示 arpa 本身及其任意层级子域(如 abc.example.arpa)
+  //    `.arpa` 仅子域; `*.arpa` 仅一级子域; 无前缀则完全匹配
+  // function domainMatch(domain, pattern) {
+  //   if (pattern.startsWith('+.')) {
+  //     const base = pattern.slice(2)
+  //     return domain === base || domain.endsWith('.' + base)
+  //   }
+  //   if (pattern.startsWith('*.')) {
+  //     const rest = domain.slice(0, -(pattern.length - 1))
+  //     return domain.endsWith(pattern.slice(1)) && rest.length > 0 && !rest.includes('.')
+  //   }
+  //   if (pattern.startsWith('.')) return domain.endsWith(pattern)
+  //   return domain === pattern
+  // }
+
+  // 4) 找到节点 server 命中的规则, 取出对应 DNS. 拿到 dns 之后如何使用请自行处理
+  // const hit = domainRules.find(([pattern]) => domainMatch($server.server, pattern))
+  // const dns = hit ? hit[1] : undefined
 
   // 脚本中使用日志 可以参考这个格式 能在前端日志查看里区分识别
   // console.log(`[SCOPE] LOG: 信息`)


### PR DESCRIPTION
对脚本过滤和脚本操作添加了raw参数，在获取到远程订阅的时候，有些机场启用了独立的
DNS服务器，就需要在脚本里面提取出来DNS部分然后通过一定的手段通过对应的DNS解析出来。

或者说其他原因，某些机场的配置里面有特殊点也需要使用脚本提取出来。

本 commit 还只是初次提交，需要查看审查后再考虑合并。