### PR TITLE
feat: 支持获取封端机场的订阅，通过API调用链获取

### DIFF
--- a/backend/src/restful/download.js
+++ b/backend/src/restful/download.js
@@ -11,6 +11,7 @@ import {
     ResourceNotFoundError,
 } from '@/restful/errors';
 import { produceArtifact } from '@/restful/sync';
+import { getCachedProviderRequestUrl } from '@/utils/provider';
 // eslint-disable-next-line no-unused-vars
 import { isIPv4, isIPv6 } from '@/utils';
 import { getISO } from '@/utils/geo';
@@ -345,6 +346,9 @@ async function downloadSubscription(req, res) {
             }
             let output = await produceArtifact(opt);
             let flowInfo;
+            if (sub.source === 'api') {
+                url = getCachedProviderRequestUrl(sub);
+            }
             if (
                 sub.source !== 'local' ||
                 ['localFirst', 'remoteFirst'].includes(sub.mergeSources)
@@ -681,7 +685,11 @@ async function downloadCollection(req, res) {
                     ) {
                         try {
                             let url =
-                                `${sub.url}`
+                                `${
+                                    sub.source === 'api'
+                                        ? getCachedProviderRequestUrl(sub)
+                                        : sub.url
+                                }`
                                     .split(/[\r\n]+/)
                                     .map((i) => i.trim())
                                     .filter((i) => i.length)?.[0] || '';

--- a/backend/src/restful/preview.js
+++ b/backend/src/restful/preview.js
@@ -3,6 +3,7 @@ import { ProxyUtils } from '@/core/proxy-utils';
 import { findByName } from '@/utils/database';
 import { success, failed } from './response';
 import download from '@/utils/download';
+import { fetchProviderSubscription } from '@/utils/provider';
 import { SUBS_KEY } from '@/constants';
 import $ from '@/core/app';
 import {
@@ -84,7 +85,13 @@ async function compareSub(req, res) {
         const target = req.query.target || 'JSON';
         let content;
         let sourceRaw;
-        if (
+        if (sub.source === 'api') {
+            const downloaded = await fetchProviderSubscription(sub, {
+                download,
+            });
+            content = [downloaded.result];
+            sourceRaw = [downloaded.raw];
+        } else if (
             sub.source === 'local' &&
             !['localFirst', 'remoteFirst'].includes(sub.mergeSources)
         ) {
@@ -242,7 +249,14 @@ async function compareCollection(req, res) {
                 try {
                     let raw;
                     let sourceRaw;
-                    if (
+                    if (sub.source === 'api') {
+                        const downloaded = await fetchProviderSubscription(sub, {
+                            download,
+                            proxy: sub.proxy || collection.proxy,
+                        });
+                        raw = [downloaded.result];
+                        sourceRaw = [downloaded.raw];
+                    } else if (
                         sub.source === 'local' &&
                         !['localFirst', 'remoteFirst'].includes(
                             sub.mergeSources,

--- a/backend/src/restful/subscriptions.js
+++ b/backend/src/restful/subscriptions.js
@@ -24,6 +24,8 @@ import {
 } from '@/utils/flow';
 import { archiveSubscription } from '@/utils/archive';
 import { success, failed } from './response';
+import download from '@/utils/download';
+import { fetchProviderSubscription } from '@/utils/provider';
 import $ from '@/core/app';
 import { formatDateTime } from '@/utils';
 import { maskAgeSecretInUrl, normalizeAgePublicKeyConfig } from '@/utils/age';
@@ -122,6 +124,12 @@ async function getFlowInfo(req, res) {
         return;
     }
     try {
+        if (sub.source === 'api') {
+            const providerResult = await fetchProviderSubscription(sub, {
+                download,
+            });
+            url = providerResult.requestUrl;
+        }
         url =
             `${url || sub.url}`
                 .split(/[\r\n]+/)

--- a/backend/src/restful/sync.js
+++ b/backend/src/restful/sync.js
@@ -14,6 +14,7 @@ import {
     shouldSyncArtifactInGlobalCron,
 } from '@/utils/artifact-cron';
 import { findByName, updateByName } from '@/utils/database';
+import { fetchProviderSubscription } from '@/utils/provider';
 import download from '@/utils/download';
 import { ProxyUtils } from '@/core/proxy-utils';
 import { RuleUtils } from '@/core/rule-utils';
@@ -367,6 +368,15 @@ async function produceArtifact({
                     raw.push(content);
                     sourceRaw.push(content);
                 }
+            } else if (sub.source === 'api') {
+                const downloaded = await fetchProviderSubscription(sub, {
+                    download,
+                    awaitCustomCache,
+                    noCache,
+                    proxy: proxy || sub.proxy,
+                });
+                raw = [downloaded.result];
+                sourceRaw = [downloaded.raw];
             } else if (
                 sub.source === 'local' &&
                 !['localFirst', 'remoteFirst'].includes(sub.mergeSources)
@@ -555,7 +565,21 @@ async function produceArtifact({
                         $.info(`正在处理子订阅：${sub.name}...`);
                         let raw;
                         let sourceRaw;
-                        if (
+                        if (sub.source === 'api') {
+                            const downloaded = await fetchProviderSubscription(
+                                sub,
+                                {
+                                    download,
+                                    noCache,
+                                    proxy:
+                                        proxy ||
+                                        sub.proxy ||
+                                        collection.proxy,
+                                },
+                            );
+                            raw = [downloaded.result];
+                            sourceRaw = [downloaded.raw];
+                        } else if (
                             sub.source === 'local' &&
                             !['localFirst', 'remoteFirst'].includes(
                                 sub.mergeSources,

--- a/backend/src/test/utils/provider.spec.js
+++ b/backend/src/test/utils/provider.spec.js
@@ -1,0 +1,273 @@
+import { expect } from 'chai';
+import crypto from 'crypto';
+import http from 'http';
+import zlib from 'zlib';
+import { after, before, beforeEach, describe, it } from 'mocha';
+
+import { SETTINGS_KEY } from '@/constants';
+
+let $;
+let provider;
+let originalRead;
+let originalWrite;
+let originalInfo;
+let originalError;
+let state;
+
+function listen(server) {
+    return new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+}
+
+function close(server) {
+    return new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+    });
+}
+
+function getServerURL(server) {
+    const address = server.address();
+    return `http://127.0.0.1:${address.port}`;
+}
+
+function createSub(cfgUrl, extra = {}) {
+    return {
+        name: 'api-demo',
+        source: 'api',
+        content: [
+            'cfgUrls:',
+            `  - ${cfgUrl}`,
+            'username: user@example.com',
+            'password: secret',
+            'headers:',
+            '  User-Agent: ProviderUA',
+            '  X-Provider: enabled',
+            'decrypt: null',
+        ].join('\n'),
+        ...extra,
+    };
+}
+
+describe('provider subscription utils', function () {
+    before(function () {
+        ({ default: $ } = require('@/core/app'));
+        provider = require('@/utils/provider');
+        originalRead = $.read.bind($);
+        originalWrite = $.write.bind($);
+        originalInfo = $.info.bind($);
+        originalError = $.error.bind($);
+    });
+
+    after(function () {
+        $.read = originalRead;
+        $.write = originalWrite;
+        $.info = originalInfo;
+        $.error = originalError;
+    });
+
+    beforeEach(function () {
+        state = { [SETTINGS_KEY]: { defaultTimeout: 3000 } };
+        $.read = (key) => state[key];
+        $.write = (value, key) => {
+            state[key] = value;
+            return true;
+        };
+        $.info = () => {};
+        $.error = () => {};
+    });
+
+    it('parses provider YAML and deliberately ignores subscribeUrl input', function () {
+        const config = provider.parseProviderConfig(
+            [
+                'cfgUrls: https://example.com/cfg',
+                'username: user',
+                'password: pass',
+                'headers:',
+                '  User-Agent: DemoUA',
+                'decrypt: null',
+                'subscribeUrl: https://should-not-be-used.example/sub',
+            ].join('\n'),
+        );
+
+        expect(config).to.deep.equal({
+            cfgUrls: ['https://example.com/cfg'],
+            username: 'user',
+            password: 'pass',
+            headers: { 'User-Agent': 'DemoUA' },
+            decrypt: null,
+        });
+        expect(config).not.to.have.property('subscribeUrl');
+    });
+
+    it('normalizes provider API base URL candidates', function () {
+        expect(
+            provider.baseURLCandidates('https://example.com/'),
+        ).to.deep.equal(['https://example.com/api/v1']);
+        expect(
+            provider.baseURLCandidates('https://example.com/api'),
+        ).to.deep.equal([
+            'https://example.com/api',
+            'https://example.com/api/v1',
+        ]);
+        expect(
+            provider.baseURLCandidates('https://example.com/api/v1'),
+        ).to.deep.equal(['https://example.com/api/v1']);
+    });
+
+    it('decodes the provider AES-CBC payload with optional gzip wrapping', function () {
+        const key = '1234567890abcdef';
+        const iv = 'abcdef1234567890';
+        const content = 'proxies:\n  - {name: Demo, type: ss}';
+        const cipher = crypto.createCipheriv('aes-128-cbc', key, iv);
+        const encrypted = Buffer.concat([
+            cipher.update(Buffer.from(content).toString('base64')),
+            cipher.final(),
+        ]).toString('base64');
+
+        expect(
+            provider.decodeProviderSubscriptionBody(encrypted, { key, iv }),
+        ).to.equal(content);
+        expect(
+            provider.decodeProviderSubscriptionBody(
+                zlib.gzipSync(Buffer.from(encrypted)),
+                { key, iv },
+            ),
+        ).to.equal(content);
+    });
+
+    it('refreshes once, caches subscribeUrl, and reuses configured headers', async function () {
+        let baseURL;
+        let cfgHits = 0;
+        let loginHits = 0;
+        let subscribeHits = 0;
+        const server = http.createServer((req, res) => {
+            if (req.url === '/cfg') {
+                cfgHits++;
+                const body = Buffer.from(
+                    JSON.stringify({ hosts: [baseURL] }),
+                ).toString('base64');
+                res.end(body);
+                return;
+            }
+            if (req.url === '/api/v1/passport/auth/login') {
+                loginHits++;
+                expect(req.headers['user-agent']).to.equal('ProviderUA');
+                res.setHeader('content-type', 'application/json');
+                res.end(JSON.stringify({ data: { auth_data: 'Bearer auth' } }));
+                return;
+            }
+            if (req.url === '/api/v1/user/getSubscribe') {
+                subscribeHits++;
+                expect(req.headers.authorization).to.equal('Bearer auth');
+                res.setHeader('content-type', 'application/json');
+                res.end(
+                    JSON.stringify({
+                        data: { subscribe_url: `${baseURL}/subscription` },
+                    }),
+                );
+                return;
+            }
+            res.statusCode = 404;
+            res.end();
+        });
+        await listen(server);
+        baseURL = getServerURL(server);
+
+        const requested = [];
+        const download = async (url) => {
+            requested.push(url);
+            return {
+                result: 'proxies:\n  - {name: Demo, type: ss}',
+                raw: 'proxies:\n  - {name: Demo, type: ss}',
+            };
+        };
+        try {
+            const sub = createSub(`${baseURL}/cfg`);
+            const first = await provider.fetchProviderSubscription(sub, {
+                download,
+            });
+            const second = await provider.fetchProviderSubscription(sub, {
+                download,
+            });
+
+            expect(first.subscribeUrl).to.equal(`${baseURL}/subscription`);
+            expect(second.subscribeUrl).to.equal(`${baseURL}/subscription`);
+            expect(cfgHits).to.equal(1);
+            expect(loginHits).to.equal(1);
+            expect(subscribeHits).to.equal(1);
+            expect(requested).to.have.length(2);
+            const args = JSON.parse(
+                decodeURIComponent(requested[0].split('#')[1]),
+            );
+            expect(JSON.parse(args.headers)).to.deep.equal({
+                'User-Agent': 'ProviderUA',
+                'X-Provider': 'enabled',
+            });
+        } finally {
+            await close(server);
+        }
+    });
+
+    it('shares an initial refresh and falls back to the token URL', async function () {
+        let baseURL;
+        let cfgHits = 0;
+        let loginHits = 0;
+        const server = http.createServer((req, res) => {
+            if (req.url === '/cfg') {
+                cfgHits++;
+                res.end(
+                    Buffer.from(JSON.stringify({ hosts: [baseURL] })).toString(
+                        'base64',
+                    ),
+                );
+                return;
+            }
+            if (req.url === '/api/v1/passport/auth/login') {
+                loginHits++;
+                res.end(JSON.stringify({ data: { auth_data: 'auth' } }));
+                return;
+            }
+            if (req.url === '/api/v1/user/getSubscribe') {
+                res.end(
+                    JSON.stringify({
+                        data: {
+                            token: 'new token',
+                            subscribe_url: `${baseURL}/expired`,
+                        },
+                    }),
+                );
+                return;
+            }
+            res.statusCode = 404;
+            res.end();
+        });
+        await listen(server);
+        baseURL = getServerURL(server);
+        const fallback = `${baseURL}/api/v1/client/subscribe?token=new%20token`;
+        let fallbackHits = 0;
+        const download = async (url) => {
+            const plainUrl = url.split('#')[0];
+            if (plainUrl.endsWith('/expired')) throw new Error('expired');
+            expect(plainUrl).to.equal(fallback);
+            fallbackHits++;
+            return { result: 'proxies: []', raw: 'proxies: []' };
+        };
+        try {
+            const sub = createSub(`${baseURL}/cfg`, {
+                name: 'api-concurrent-demo',
+            });
+            const [first, second] = await Promise.all([
+                provider.fetchProviderSubscription(sub, { download }),
+                provider.fetchProviderSubscription(sub, { download }),
+            ]);
+            expect(first.subscribeUrl).to.equal(fallback);
+            expect(second.subscribeUrl).to.equal(fallback);
+            expect(cfgHits).to.equal(1);
+            expect(loginHits).to.equal(1);
+            expect(fallbackHits).to.equal(1);
+        } finally {
+            await close(server);
+        }
+    });
+});

--- a/backend/src/utils/provider.js
+++ b/backend/src/utils/provider.js
@@ -1,0 +1,506 @@
+import { Buffer } from 'buffer';
+import { Base64 } from 'js-base64';
+
+import $ from '@/core/app';
+import { SETTINGS_KEY } from '@/constants';
+import { getPolicyDescriptor } from '@/utils';
+import { hex_md5 } from '@/vendor/md5';
+import { ENV, HTTP } from '@/vendor/open-api';
+import resourceCache from '@/utils/resource-cache';
+import { safeLoad } from '@/utils/yaml';
+import { runBackendRequestTask } from '@/utils/request-concurrency';
+
+const CFG_USER_AGENT = 'Mozilla/5.0 (dart:io) SuperAccelerator';
+const PROVIDER_SUBSCRIBE_URL_CACHE_PREFIX =
+    '#sub-store-cached-provider-subscribe-url-';
+const refreshTasks = new Map();
+
+function normalizeString(value) {
+    return value == null ? '' : `${value}`;
+}
+
+function normalizeHeaders(headers) {
+    if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+        return {};
+    }
+    return Object.fromEntries(
+        Object.entries(headers)
+            .filter(([key, value]) => key && value != null)
+            .map(([key, value]) => [`${key}`, `${value}`]),
+    );
+}
+
+function normalizeDecrypt(decrypt) {
+    if (decrypt == null) return null;
+    if (typeof decrypt !== 'object' || Array.isArray(decrypt)) {
+        throw new Error('API 订阅 decrypt 必须为 null 或对象');
+    }
+    return {
+        key: normalizeString(decrypt.key),
+        iv: normalizeString(decrypt.iv),
+    };
+}
+
+function parseProviderConfig(content) {
+    let raw;
+    try {
+        raw = safeLoad(normalizeString(content));
+    } catch (e) {
+        throw new Error(`API 订阅 YAML 解析失败: ${e.message ?? e}`);
+    }
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        throw new Error('API 订阅 YAML 必须为对象');
+    }
+
+    const cfgUrls = (
+        Array.isArray(raw.cfgUrls)
+            ? raw.cfgUrls
+            : raw.cfgUrls == null
+            ? []
+            : [raw.cfgUrls]
+    )
+        .map((url) => normalizeString(url).trim())
+        .filter(Boolean);
+    if (cfgUrls.length === 0) {
+        throw new Error('API 订阅 cfgUrls 不能为空');
+    }
+
+    return {
+        cfgUrls,
+        username: normalizeString(raw.username),
+        password: normalizeString(raw.password),
+        headers: normalizeHeaders(raw.headers),
+        decrypt: normalizeDecrypt(raw.decrypt),
+    };
+}
+
+function stableStringify(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableStringify).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value)
+            .sort()
+            .map(
+                (key) =>
+                    `${JSON.stringify(key)}:${stableStringify(value[key])}`,
+            )
+            .join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function getProviderSubscribeUrlCacheKey(config) {
+    return `${PROVIDER_SUBSCRIBE_URL_CACHE_PREFIX}${hex_md5(
+        stableStringify(config),
+    )}`;
+}
+
+function getCachedProviderSubscribeUrl(config) {
+    return normalizeString(
+        $.read(getProviderSubscribeUrlCacheKey(config)),
+    ).trim();
+}
+
+function getCachedProviderRequestUrl(sub) {
+    const config = parseProviderConfig(sub.content);
+    const subscribeUrl = getCachedProviderSubscribeUrl(config);
+    return subscribeUrl
+        ? buildProviderDownloadUrl(subscribeUrl, config.headers)
+        : '';
+}
+
+function setCachedProviderSubscribeUrl(config, url) {
+    $.write(
+        normalizeString(url).trim(),
+        getProviderSubscribeUrlCacheKey(config),
+    );
+}
+
+function getHeader(headers, name) {
+    const target = name.toLowerCase();
+    const entry = Object.entries(headers).find(
+        ([key]) => key.toLowerCase() === target,
+    );
+    return entry?.[1];
+}
+
+function normalizeBaseURL(baseURL) {
+    return normalizeString(baseURL).trim().replace(/\/+$/, '');
+}
+
+function baseURLCandidates(baseURL) {
+    const normalized = normalizeBaseURL(baseURL);
+    if (!normalized) return [];
+    if (normalized.endsWith('/api/v1')) return [normalized];
+    if (normalized.endsWith('/api')) {
+        return [normalized, `${normalized}/v1`];
+    }
+    return [`${normalized}/api/v1`];
+}
+
+function fallbackSubscribeURL(baseURL, token) {
+    return `${normalizeBaseURL(
+        baseURL,
+    )}/client/subscribe?token=${encodeURIComponent(token)}`;
+}
+
+function decodeBase64String(value) {
+    const normalized = normalizeString(value)
+        .trim()
+        .replace(/^\uFEFF/, '')
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+    try {
+        return Base64.decode(normalized);
+    } catch (e) {
+        throw new Error(`cfgUrl Base64 解码失败: ${e.message ?? e}`);
+    }
+}
+
+function getProviderRequestOptions({ headers, proxy, url }) {
+    const { isLoon, isShadowRocket, isQX, isStash } = ENV();
+    return {
+        url,
+        ...(proxy ? { proxy } : {}),
+        ...(isLoon && proxy ? { node: proxy } : {}),
+        ...(isQX && proxy ? { opts: { policy: proxy } } : {}),
+        ...(proxy ? getPolicyDescriptor(proxy) : {}),
+        headers: {
+            ...headers,
+            ...(isStash && proxy
+                ? { 'X-Stash-Selected-Proxy': encodeURIComponent(proxy) }
+                : {}),
+            ...(isShadowRocket && proxy ? { 'X-Surge-Policy': proxy } : {}),
+        },
+    };
+}
+
+async function providerRequest({
+    method = 'get',
+    url,
+    encoding,
+    headers = {},
+    body,
+    proxy: customProxy,
+}) {
+    const settings = $.read(SETTINGS_KEY) || {};
+    let proxy = customProxy || settings.defaultProxy;
+    if ($.env.isNode) {
+        proxy = proxy || globalThis.process?.env?.SUB_STORE_BACKEND_DEFAULT_PROXY;
+    }
+    const timeout = settings.defaultTimeout || 8000;
+    const http = HTTP({ timeout });
+    const options = getProviderRequestOptions({ headers, proxy, url });
+    if (body !== undefined) options.body = JSON.stringify(body);
+    if (encoding !== undefined) options.encoding = encoding;
+    const response = await runBackendRequestTask(
+        () => http[method](options),
+        'provider',
+    );
+    if (response.statusCode !== 200 || response.body == null) {
+        throw new Error(`${url} 返回状态码 ${response.statusCode}`);
+    }
+    return response;
+}
+
+async function fetchConfigHosts(cfgUrl, proxy) {
+    const response = await providerRequest({
+        url: cfgUrl,
+        headers: { 'User-Agent': CFG_USER_AGENT },
+        proxy,
+    });
+    const decoded = decodeBase64String(response.body);
+    let config;
+    try {
+        config = JSON.parse(decoded);
+    } catch (e) {
+        throw new Error(`cfgUrl JSON 解析失败: ${e.message ?? e}`);
+    }
+    const hosts = [
+        ...(Array.isArray(config.hosts) ? config.hosts : []),
+        config.host_source,
+    ]
+        .map((host) => normalizeString(host).trim())
+        .filter(Boolean);
+    if (hosts.length === 0) throw new Error('cfgUrl 未返回可用 hosts');
+    return hosts;
+}
+
+async function fetchBaseURLs(config, proxy) {
+    const results = await Promise.all(
+        config.cfgUrls.map(async (cfgUrl) => {
+            try {
+                return await fetchConfigHosts(cfgUrl, proxy);
+            } catch (error) {
+                $.error(`API 订阅 cfgUrl ${cfgUrl} 获取失败: ${error}`);
+                return [];
+            }
+        }),
+    );
+    const seen = new Set();
+    const baseURLs = [];
+    results.flat().forEach((host) => {
+        baseURLCandidates(host).forEach((candidate) => {
+            if (!seen.has(candidate)) {
+                seen.add(candidate);
+                baseURLs.push(candidate);
+            }
+        });
+    });
+    if (baseURLs.length === 0) {
+        throw new Error('API 订阅未找到可用的服务地址');
+    }
+    return baseURLs;
+}
+
+async function login(baseURL, config, headers, proxy) {
+    const response = await providerRequest({
+        method: 'post',
+        url: `${baseURL}/passport/auth/login`,
+        headers: {
+            ...headers,
+            'Content-Type': 'application/json',
+        },
+        body: {
+            email: config.username,
+            password: config.password,
+        },
+        proxy,
+    });
+    const data = JSON.parse(response.body);
+    const authData = normalizeString(data?.data?.auth_data);
+    if (!authData) throw new Error('登录响应缺少 auth_data');
+    return authData;
+}
+
+async function getSubscribe(baseURL, authData, headers, proxy) {
+    const response = await providerRequest({
+        url: `${baseURL}/user/getSubscribe`,
+        headers: {
+            ...headers,
+            Authorization: authData,
+        },
+        proxy,
+    });
+    const data = JSON.parse(response.body)?.data || {};
+    const subscribeUrl = normalizeString(data.subscribe_url).trim();
+    const token = normalizeString(data.token).trim();
+    if (!subscribeUrl && !token) {
+        throw new Error('getSubscribe 响应缺少 subscribe_url 或 token');
+    }
+    return { subscribeUrl, token };
+}
+
+function buildProviderDownloadUrl(url, headers) {
+    const normalizedHeaders = normalizeHeaders(headers);
+    if (Object.keys(normalizedHeaders).length === 0) return url;
+    const baseUrl = normalizeString(url).split('#')[0];
+    return `${baseUrl}#${encodeURIComponent(
+        JSON.stringify({ headers: JSON.stringify(normalizedHeaders) }),
+    )}`;
+}
+
+function loadNodeBuiltin(name) {
+    const processObject = globalThis.process;
+    if (typeof processObject?.getBuiltinModule === 'function') {
+        return processObject.getBuiltinModule(name);
+    }
+    const mainModule = processObject?.mainModule;
+    if (typeof mainModule?.require !== 'function') {
+        throw new Error(`当前 Node.js 环境无法加载内置模块 ${name}`);
+    }
+    return mainModule.require(name);
+}
+
+function gunzipIfNeeded(body) {
+    const bytes = Buffer.isBuffer(body) ? body : Buffer.from(body);
+    if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
+        return bytes;
+    }
+    if (!$.env.isNode) {
+        throw new Error('当前运行环境不支持 API 订阅 gzip 解密');
+    }
+    const zlib = loadNodeBuiltin('zlib');
+    return zlib.gunzipSync(bytes);
+}
+
+function decodeProviderSubscriptionBody(body, decrypt) {
+    if (!decrypt) return normalizeString(body);
+    if (!$.env.isNode) {
+        throw new Error('当前运行环境不支持 API 订阅 AES 解密');
+    }
+    const crypto = loadNodeBuiltin('crypto');
+    const encoded = gunzipIfNeeded(body).toString('utf8').trim();
+    const key = Buffer.from(decrypt.key);
+    const iv = Buffer.from(decrypt.iv);
+    if (key.length !== 16 || iv.length !== 16) {
+        throw new Error('API 订阅 AES key 和 iv 必须均为 16 字节');
+    }
+    const decipher = crypto.createDecipheriv('aes-128-cbc', key, iv);
+    const plainText = Buffer.concat([
+        decipher.update(Buffer.from(encoded, 'base64')),
+        decipher.final(),
+    ]);
+    return Buffer.from(plainText.toString('utf8').trim(), 'base64').toString(
+        'utf8',
+    );
+}
+
+async function fetchEncryptedProviderContent({ url, headers, proxy, noCache }) {
+    const id = hex_md5(`provider-encrypted:${stableStringify(headers)}:${url}`);
+    let encoded = !noCache ? resourceCache.get(id) : null;
+    let bytes;
+    if (encoded) {
+        bytes = Buffer.from(encoded, 'base64');
+    } else {
+        const response = await providerRequest({
+            url,
+            headers,
+            proxy,
+            encoding: null,
+        });
+        bytes = Buffer.from(response.body);
+        if (bytes.length === 0) throw new Error('API 订阅内容为空');
+
+        const settings = $.read(SETTINGS_KEY) || {};
+        const cacheThreshold = settings.cacheThreshold || 1024;
+        if (!cacheThreshold || bytes.length / 1024 <= cacheThreshold) {
+            encoded = bytes.toString('base64');
+            resourceCache.set(id, encoded);
+        }
+    }
+    return bytes;
+}
+
+async function fetchProviderSubscription(sub, options = {}) {
+    const config = parseProviderConfig(sub.content);
+    const cacheKey = getProviderSubscribeUrlCacheKey(config);
+    const proxy = options.proxy || sub.proxy;
+    const authHeaders = {};
+    const configuredUserAgent = getHeader(config.headers, 'user-agent');
+    if (configuredUserAgent) authHeaders['User-Agent'] = configuredUserAgent;
+
+    const fetchContent = async (subscribeUrl) => {
+        const requestUrl = buildProviderDownloadUrl(
+            subscribeUrl,
+            config.headers,
+        );
+        const downloaded = config.decrypt
+            ? await fetchEncryptedProviderContent({
+                  url: subscribeUrl,
+                  headers: config.headers,
+                  proxy,
+                  noCache: options.noCache || sub.noCache,
+              })
+            : await options.download(
+                  requestUrl,
+                  undefined,
+                  undefined,
+                  proxy,
+                  undefined,
+                  options.awaitCustomCache,
+                  options.noCache || sub.noCache,
+                  true,
+                  { returnRaw: true },
+              );
+        if (!config.decrypt) {
+            return {
+                result: downloaded.result ?? downloaded,
+                raw: downloaded.raw ?? downloaded,
+                subscribeUrl,
+                requestUrl,
+            };
+        }
+        const decoded = decodeProviderSubscriptionBody(
+            downloaded.raw ?? downloaded.result ?? downloaded,
+            config.decrypt,
+        );
+        return {
+            result: decoded,
+            raw: decoded,
+            subscribeUrl,
+            requestUrl,
+        };
+    };
+
+    const cachedUrl = getCachedProviderSubscribeUrl(config);
+    if (cachedUrl) {
+        try {
+            return await fetchContent(cachedUrl);
+        } catch (error) {
+            $.info(`API 订阅缓存 subscribeUrl 已失效，将重新获取: ${error}`);
+            setCachedProviderSubscribeUrl(config, '');
+        }
+    }
+
+    if (refreshTasks.has(cacheKey)) return refreshTasks.get(cacheKey);
+
+    const task = (async () => {
+        const refreshedCachedUrl = getCachedProviderSubscribeUrl(config);
+        if (refreshedCachedUrl) return fetchContent(refreshedCachedUrl);
+
+        const baseURLs = await fetchBaseURLs(config, proxy);
+        let lastError;
+        for (const baseURL of baseURLs) {
+            try {
+                const authData = await login(
+                    baseURL,
+                    config,
+                    authHeaders,
+                    proxy,
+                );
+                const { subscribeUrl, token } = await getSubscribe(
+                    baseURL,
+                    authData,
+                    authHeaders,
+                    proxy,
+                );
+                const candidates = [subscribeUrl];
+                if (token) {
+                    baseURLs.forEach((fallbackBaseURL) => {
+                        candidates.push(
+                            fallbackSubscribeURL(fallbackBaseURL, token),
+                        );
+                    });
+                }
+                for (const candidate of candidates.filter(Boolean)) {
+                    try {
+                        const result = await fetchContent(candidate);
+                        setCachedProviderSubscribeUrl(config, candidate);
+                        return result;
+                    } catch (error) {
+                        lastError = error;
+                    }
+                }
+            } catch (error) {
+                lastError = error;
+            }
+        }
+        throw new Error(
+            `API 订阅获取失败: ${
+                lastError?.message ?? lastError ?? '无可用订阅地址'
+            }`,
+        );
+    })();
+    refreshTasks.set(cacheKey, task);
+    try {
+        return await task;
+    } finally {
+        refreshTasks.delete(cacheKey);
+    }
+}
+
+export {
+    CFG_USER_AGENT,
+    PROVIDER_SUBSCRIBE_URL_CACHE_PREFIX,
+    baseURLCandidates,
+    buildProviderDownloadUrl,
+    decodeProviderSubscriptionBody,
+    fallbackSubscribeURL,
+    getCachedProviderRequestUrl,
+    fetchProviderSubscription,
+    getCachedProviderSubscribeUrl,
+    getProviderSubscribeUrlCacheKey,
+    parseProviderConfig,
+};


### PR DESCRIPTION
## 功能描述

本 PR 为 Sub-Store 单条订阅新增第三种来源类型：**API 订阅**。

API 订阅类型面向封端机场使用，通过机场 API 调用链动态获取 Mihomo 格式订阅。

### 配置格式

```yaml
cfgUrls:
  - https://muguang9.oss-ap-southeast-1.aliyuncs.com/ConFigOss-muguang.json
username:
password:
headers:
  User-Agent: NetFlow/v3.0.6 clash-verge Platform/linux
decrypt: null
```

支持的主要参数：

- `cfgUrls`：机场 API 服务地址配置来源，可填写多个。
- `username`：机场登录用户名。
- `password`：机场登录密码。
- `headers`：登录及订阅请求所使用的请求头。
- `decrypt`：可选的 AES-CBC 解密配置，支持 `key` 和 `iv`。

配套项目，从 Windwos 客户端中一键提取配置：https://alecthw.github.io/sub-cfg-export/

### 后端功能

- 并发获取并解析多个 `cfgUrls`。
- Base64 解码配置内容并读取 `hosts`、`host_source`。
- 自动补全和尝试 `/api/v1` API 地址。
- 调用 `/passport/auth/login` 登录。
- 调用 `/user/getSubscribe` 获取 `subscribe_url` 或 token。
- 当 `subscribe_url` 不可用时，使用 token 构造 fallback 订阅地址。
- 支持配置自定义请求头和后端代理。
- 支持 gzip 内容解压及 AES-128-CBC 解密。
- 最终订阅内容按 Mihomo 格式交给原有订阅解析、节点操作和输出流程处理。
- 支持单条订阅、组合订阅、即时预览、流量查询及响应头转发。

### 缓存行为

- `subscribeUrl` 根据 API 参数配置指纹进行持久化缓存。
- 后续请求优先使用缓存的 `subscribeUrl`，避免每次重新登录和调用 API。
- 仅当缓存的 `subscribeUrl` 获取失败时，才重新执行完整 API 调用链。
- 未加密订阅内容复用原有远程订阅的 `download()` 缓存机制。
- 加密订阅内容使用二进制资源缓存，避免 gzip 数据在文本解码过程中损坏。
- 继续支持原有缓存 TTL、缓存大小限制和 `noCache` 行为。

### 前端功能

- 单条订阅来源新增“API订阅”选项。
- 提供 YAML 参数编辑器及必填校验。
- API 订阅支持列表筛选和流量信息展示。
- 参数编辑器顶部提供参数获取教程按钮：
  - <https://alecthw.github.io/sub-cfg-export/>
- 教程按钮仅在选择“API订阅”时显示。
- 修复长占位说明导致编辑器和工具栏横向溢出的问题。

## 订阅获取流程

```mermaid
flowchart TD
    A["读取 API 订阅 YAML 参数"] --> B["校验并规范化 cfgUrls、账号、密码、headers、decrypt"]
    B --> C["根据配置指纹读取持久化 subscribeUrl 缓存"]
    C --> D{"存在缓存的 subscribeUrl？"}

    D -- "是" --> E["使用配置 headers 获取订阅内容"]
    E --> F{"内容获取及解码成功？"}
    F -- "是" --> P["进入订阅内容处理流程"]
    F -- "否" --> G["清除失效的 subscribeUrl 缓存"]

    D -- "否" --> H["并发请求全部 cfgUrls"]
    G --> H

    H --> I["Base64 解码 cfgUrl 响应"]
    I --> J["读取 hosts 和 host_source"]
    J --> K["生成、规范化并去重 API Base URL"]
    K --> L["依次调用 /passport/auth/login"]

    L --> M{"登录成功？"}
    M -- "否" --> N{"还有其他 Base URL？"}
    N -- "是" --> L
    N -- "否" --> Z["返回 API 订阅获取失败"]

    M -- "是" --> O["携带 Authorization 调用 /user/getSubscribe"]
    O --> Q{"返回 subscribe_url？"}

    Q -- "是" --> R["尝试使用 subscribe_url 获取订阅"]
    R --> S{"获取成功？"}
    S -- "是" --> T["持久化缓存 subscribeUrl"]
    S -- "否" --> U{"返回 token？"}

    Q -- "否" --> U
    U -- "是" --> V["使用 token 为各 Base URL 构造 /client/subscribe fallback 地址"]
    V --> W["依次尝试 fallback 订阅地址"]
    W --> X{"获取成功？"}
    X -- "是" --> T
    X -- "否" --> N
    U -- "否" --> N

    T --> P
    P --> Y{"配置 decrypt？"}
    Y -- "是" --> AA["读取二进制缓存或下载原始内容"]
    AA --> AB["按需 gzip 解压"]
    AB --> AC["AES-128-CBC 解密"]
    AC --> AD["Base64 解码订阅内容"]

    Y -- "否" --> AE["复用远程订阅 download 缓存流程"]
    AD --> AF["解析 Mihomo 格式节点"]
    AE --> AF

    AF --> AG["执行节点过滤、重命名、脚本等处理器"]
    AG --> AH["按目标平台生成最终订阅"]
```
