### PR TITLE
feat: Shadowsocks v2ray-plugin plugin-opts 中 mode 使用真实取值; 增强 V2Ray UR…

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sub-store",
-  "version": "2.21.96",
+  "version": "2.21.98",
   "description": "Advanced Subscription Manager for QX, Loon, Surge, Stash and Shadowrocket.",
   "main": "src/main.js",
   "scripts": {

--- a/backend/src/core/proxy-utils/parsers/index.js
+++ b/backend/src/core/proxy-utils/parsers/index.js
@@ -318,7 +318,10 @@ function URI_SS() {
                 case 'v2ray-plugin':
                     proxy.plugin = 'v2ray-plugin';
                     proxy['plugin-opts'] = {
-                        mode: 'websocket',
+                        mode:
+                            getIfNotBlank(params['obfs']) ||
+                            getIfNotBlank(params['mode']) ||
+                            'websocket',
                         host:
                             getIfNotBlank(params['obfs-host']) ||
                             getIfNotBlank(params['host']),

--- a/backend/src/core/proxy-utils/producers/clashmeta.js
+++ b/backend/src/core/proxy-utils/producers/clashmeta.js
@@ -1,6 +1,7 @@
 import {
     isPresent,
     produceProxyListOutput,
+    supportsShadowsocksV2rayPluginMode,
 } from '@/core/proxy-utils/producers/utils';
 
 const ipVersions = {
@@ -17,7 +18,11 @@ export default function ClashMeta_Producer() {
         const list = proxies
             .filter((proxy) => {
                 if (opts['include-unsupported-proxy']) return true;
-                if (proxy.type === 'snell' && proxy.version >= 4) {
+                if (
+                    !supportsShadowsocksV2rayPluginMode(proxy, ['websocket'])
+                ) {
+                    return false;
+                } else if (proxy.type === 'snell' && proxy.version >= 4) {
                     return false;
                 } else if (
                     ['tailscale', 'juicity', 'naive'].includes(proxy.type)

--- a/backend/src/core/proxy-utils/producers/egern.js
+++ b/backend/src/core/proxy-utils/producers/egern.js
@@ -152,10 +152,18 @@ export default function Egern_Producer() {
                                 proxy.udp || proxy.udp_relay || proxy.udp_relay,
                             next_hop: proxy.next_hop,
                         };
-                        if (original.plugin === 'obfs') {
-                            proxy.obfs = original['plugin-opts'].mode;
-                            proxy.obfs_host = original['plugin-opts'].host;
-                            proxy.obfs_uri = original['plugin-opts'].path;
+                        if (isPresent(proxy, 'plugin')) {
+                            if (original.plugin === 'obfs') {
+                                proxy.obfs = original['plugin-opts'].mode;
+                                proxy.obfs_host = original['plugin-opts'].host;
+                                proxy.obfs_uri = original['plugin-opts'].path;
+                            } else if (
+                                !['shadow-tls'].includes(original.plugin)
+                            ) {
+                                throw new Error(
+                                    `plugin ${original.plugin} is not supported`,
+                                );
+                            }
                         }
                     } else if (proxy.type === 'hysteria2') {
                         proxy = {

--- a/backend/src/core/proxy-utils/producers/shadowrocket.js
+++ b/backend/src/core/proxy-utils/producers/shadowrocket.js
@@ -2,6 +2,7 @@ import {
     isPresent,
     isShadowsocksOverTls,
     produceProxyListOutput,
+    supportsShadowsocksV2rayPluginMode,
 } from '@/core/proxy-utils/producers/utils';
 import $ from '@/core/app';
 
@@ -11,7 +12,17 @@ export default function Shadowrocket_Producer() {
         const list = proxies
             .filter((proxy) => {
                 if (opts['include-unsupported-proxy']) return true;
-                if (proxy.type === 'snell' && proxy.version >= 4) {
+                if (
+                    !supportsShadowsocksV2rayPluginMode(proxy, [
+                        'websocket',
+                        'quic',
+                        'http2',
+                        'mkcp',
+                        'grpc',
+                    ])
+                ) {
+                    return false;
+                } else if (proxy.type === 'snell' && proxy.version >= 4) {
                     return false;
                 } else if (
                     [

--- a/backend/src/core/proxy-utils/producers/stash.js
+++ b/backend/src/core/proxy-utils/producers/stash.js
@@ -1,6 +1,7 @@
 import {
     isPresent,
     produceProxyListOutput,
+    supportsShadowsocksV2rayPluginMode,
 } from '@/core/proxy-utils/producers/utils';
 import $ from '@/core/app';
 
@@ -10,6 +11,7 @@ export default function Stash_Producer() {
         // https://stash.wiki/proxy-protocols/proxy-types#shadowsocks
         const list = proxies
             .filter((proxy) => {
+                if (opts['include-unsupported-proxy']) return true;
                 if (
                     ![
                         'ss',
@@ -49,6 +51,10 @@ export default function Stash_Producer() {
                             '2022-blake3-aes-256-gcm',
                         ].includes(proxy.cipher)) ||
                     (proxy.type === 'snell' && proxy.version >= 4)
+                ) {
+                    return false;
+                } else if (
+                    !supportsShadowsocksV2rayPluginMode(proxy, ['websocket'])
                 ) {
                     return false;
                 } else if (

--- a/backend/src/core/proxy-utils/producers/uri.js
+++ b/backend/src/core/proxy-utils/producers/uri.js
@@ -548,14 +548,15 @@ export default function URI_Producer() {
                             break;
                         case 'v2ray-plugin':
                             const mux = normalizePluginMuxValue(opts.mux);
+                            // 为了兼容性 多输出 mode 和 host 两个字段
                             query += encodeURIComponent(
-                                `v2ray-plugin;obfs=${opts.mode}${
-                                    opts.host ? ';obfs-host=' + opts.host : ''
-                                }${opts.host ? ';host=' + opts.host : ''}${
-                                    opts.path ? ';path=' + opts.path : ''
-                                }${opts.tls ? ';tls' : ''}${
-                                    opts.sni ? ';sni=' + opts.sni : ''
-                                }${
+                                `v2ray-plugin;obfs=${opts.mode};mode=${
+                                    opts.mode
+                                }${opts.host ? ';obfs-host=' + opts.host : ''}${
+                                    opts.host ? ';host=' + opts.host : ''
+                                }${opts.path ? ';path=' + opts.path : ''}${
+                                    opts.tls ? ';tls' : ''
+                                }${opts.sni ? ';sni=' + opts.sni : ''}${
                                     opts['skip-cert-verify']
                                         ? ';skip-cert-verify=' +
                                           opts['skip-cert-verify']

--- a/backend/src/core/proxy-utils/producers/utils.js
+++ b/backend/src/core/proxy-utils/producers/utils.js
@@ -54,6 +54,17 @@ export function normalizePluginMuxValue(mux) {
     return mux;
 }
 
+export function supportsShadowsocksV2rayPluginMode(proxy, supportedModes) {
+    if (proxy?.type !== 'ss' || proxy?.plugin !== 'v2ray-plugin') return true;
+
+    const normalizedMode =
+        typeof proxy?.['plugin-opts']?.mode === 'string'
+            ? proxy['plugin-opts'].mode.trim().toLowerCase()
+            : proxy?.['plugin-opts']?.mode;
+
+    return supportedModes.includes(normalizedMode);
+}
+
 export function produceProxyListOutput(list, type, opts = {}) {
     if (type === 'internal') return list;
 

--- a/backend/src/test/proxy-producers/structured.spec.js
+++ b/backend/src/test/proxy-producers/structured.spec.js
@@ -99,6 +99,89 @@ describe('Proxy structured producers', function () {
         });
     });
 
+    it('keeps only websocket shadowsocks v2ray-plugin modes for Mihomo and Stash by default', function () {
+        const buildProxy = (name, mode) => ({
+            type: 'ss',
+            name,
+            server: 'ss.example.com',
+            port: 8388,
+            cipher: 'aes-128-gcm',
+            password: 'secret',
+            plugin: 'v2ray-plugin',
+            'plugin-opts': {
+                mode,
+                host: 'cdn.example.com',
+                path: '/socket',
+                tls: true,
+            },
+        });
+
+        const proxies = [
+            buildProxy('WS', 'websocket'),
+            buildProxy('QUIC', 'quic'),
+        ];
+
+        for (const platform of ['Mihomo', 'Stash']) {
+            const internal = produceInternal(platform, proxies);
+            const external = loadProducedYaml(platform, proxies, {
+                'include-unsupported-proxy': true,
+            });
+
+            expect(internal, platform).to.have.length(1);
+            expect(internal[0].name, platform).to.equal('WS');
+            expect(external.proxies.map((proxy) => proxy.name), platform).to
+                .deep.equal(['WS', 'QUIC']);
+        }
+    });
+
+    it('keeps only supported shadowsocks v2ray-plugin modes for Shadowrocket by default', function () {
+        const buildProxy = (name, mode) => ({
+            type: 'ss',
+            name,
+            server: 'ss.example.com',
+            port: 8388,
+            cipher: 'aes-128-gcm',
+            password: 'secret',
+            plugin: 'v2ray-plugin',
+            'plugin-opts': {
+                mode,
+                host: 'cdn.example.com',
+                path: '/socket',
+                tls: true,
+            },
+        });
+
+        const proxies = [
+            buildProxy('WS', 'websocket'),
+            buildProxy('QUIC', 'quic'),
+            buildProxy('HTTP2', 'http2'),
+            buildProxy('MKCP', 'mkcp'),
+            buildProxy('GRPC', 'grpc'),
+            buildProxy('TLS', 'tls'),
+        ];
+
+        const internal = produceInternal('Shadowrocket', proxies);
+        const external = loadProducedYaml('Shadowrocket', proxies, {
+            'include-unsupported-proxy': true,
+        });
+
+        expect(internal.map((proxy) => proxy.name)).to.deep.equal([
+            'WS',
+            'QUIC',
+            'HTTP2',
+            'MKCP',
+            'GRPC',
+        ]);
+        expect(external.proxies.map((proxy) => proxy.name)).to.deep.equal([
+            'WS',
+            'QUIC',
+            'HTTP2',
+            'MKCP',
+            'GRPC',
+            'TLS',
+        ]);
+    });
+
     it('adds Clash.Meta reality defaults and preserves websocket early data', function () {
         const proxy = {
             type: 'vless',

--- a/backend/src/test/proxy-producers/text.spec.js
+++ b/backend/src/test/proxy-producers/text.spec.js
@@ -589,7 +589,7 @@ describe('Proxy text producers', function () {
 
     it('produces URI shadowsocks links with v2ray-plugin mux and tls flags', function () {
         const plugin = encodeURIComponent(
-            'v2ray-plugin;obfs=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;sni=sni.example.com;skip-cert-verify=true;mux=0',
+            'v2ray-plugin;obfs=websocket;mode=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;sni=sni.example.com;skip-cert-verify=true;mux=0',
         );
         const output = produceExternal('URI', {
             type: 'ss',
@@ -619,10 +619,10 @@ describe('Proxy text producers', function () {
 
     it('normalizes boolean v2ray-plugin mux values to integers in URI links', function () {
         const muxOnPlugin = encodeURIComponent(
-            'v2ray-plugin;obfs=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;mux=1',
+            'v2ray-plugin;obfs=websocket;mode=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;mux=1',
         );
         const muxOffPlugin = encodeURIComponent(
-            'v2ray-plugin;obfs=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;mux=0',
+            'v2ray-plugin;obfs=websocket;mode=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;mux=0',
         );
 
         const muxOnOutput = produceExternal('URI', {
@@ -701,10 +701,10 @@ describe('Proxy text producers', function () {
         const output = produceExternal('URI', proxies);
         const userInfo = Base64.encode('aes-128-gcm:secret');
         const muxOnPlugin = encodeURIComponent(
-            'v2ray-plugin;obfs=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;mux=1',
+            'v2ray-plugin;obfs=websocket;mode=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;mux=1',
         );
         const muxOffPlugin = encodeURIComponent(
-            'v2ray-plugin;obfs=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;mux=0',
+            'v2ray-plugin;obfs=websocket;mode=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;mux=0',
         );
 
         expect(output).to.equal(
@@ -747,10 +747,10 @@ describe('Proxy text producers', function () {
         const output = produceExternal('URI', proxies);
         const userInfo = Base64.encode('aes-128-gcm:secret');
         const muxOnPlugin = encodeURIComponent(
-            'v2ray-plugin;obfs=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;mux=1',
+            'v2ray-plugin;obfs=websocket;mode=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;tls;mux=1',
         );
         const muxOffPlugin = encodeURIComponent(
-            'v2ray-plugin;obfs=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;mux=0',
+            'v2ray-plugin;obfs=websocket;mode=websocket;obfs-host=cdn.example.com;host=cdn.example.com;path=/socket;mux=0',
         );
 
         expect(output).to.equal(


### PR DESCRIPTION
…I 兼容性; Egern 过滤掉 v2ray-plugin; Shadowsocks v2ray-plugin plugin-opts 的 mode 相关的逻辑调整

1. mihomo 仅支持 mode: websocket
2. stash 仅支持 mode: websocket
3. shadowrocket 仅支持 mode: websocket 或 quic 或 http2  或 mkcp 或 grpc
4. sing-box 仅支持 mode: websocket 或 quic