### PR TITLE
Skip flow header fetch when static sub-userinfo exists

### DIFF
--- a/backend/src/restful/download.js
+++ b/backend/src/restful/download.js
@@ -377,7 +377,13 @@ async function downloadSubscription(req, res) {
                             }
                         }
                     }
-                    if (!$arguments.noFlow && /^https?/.test(url)) {
+                    if (
+                        shouldFetchRemoteFlowHeaders(
+                            $arguments,
+                            sub.subUserinfo,
+                            url,
+                        )
+                    ) {
                         // forward flow headers
                         flowInfo = await getFlowHeaders(
                             $arguments?.insecure ? `${url}#insecure` : url,
@@ -542,6 +548,18 @@ async function downloadSubscription(req, res) {
             404,
         );
     }
+}
+
+export function shouldFetchRemoteFlowHeaders(
+    $arguments = {},
+    subUserinfo,
+    url,
+) {
+    if ($arguments.noFlow || !/^https?/.test(url)) {
+        return false;
+    }
+
+    return !subUserinfo || /^https?:\/\//.test(subUserinfo);
 }
 
 async function downloadCollection(req, res) {

--- a/backend/src/test/restful/download.spec.js
+++ b/backend/src/test/restful/download.spec.js
@@ -8,6 +8,7 @@ const VLESS_WS = `vless://${UUID}@1.1.1.1:443?security=tls&type=ws&host=cdn.exam
 
 let $;
 let registerDownloadRoutes;
+let shouldFetchRemoteFlowHeaders;
 let originalError;
 let originalInfo;
 let originalNotify;
@@ -171,7 +172,10 @@ async function expectDecryptFailure(armored, secretKey) {
 describe('download routes', function () {
     before(async function () {
         ({ default: $ } = require('@/core/app'));
-        ({ default: registerDownloadRoutes } = require('@/restful/download'));
+        ({
+            default: registerDownloadRoutes,
+            shouldFetchRemoteFlowHeaders,
+        } = require('@/restful/download'));
         ageUtils = require('@/utils/age');
 
         originalRead = $.read.bind($);
@@ -681,4 +685,43 @@ describe('download routes', function () {
         await expectDecryptFailure(res.sent, sourcePair['age-secret-key']);
     });
 
+    it('skips remote flow header requests when static sub-userinfo is configured', function () {
+        expect(
+            shouldFetchRemoteFlowHeaders(
+                {},
+                'upload=1; download=2; total=3',
+                'https://example.com/sub',
+            ),
+        ).to.equal(false);
+    });
+
+    it('keeps remote flow header requests for custom flow URLs or missing sub-userinfo', function () {
+        expect(
+            shouldFetchRemoteFlowHeaders(
+                {},
+                'https://example.com/flow',
+                'https://example.com/sub',
+            ),
+        ).to.equal(true);
+        expect(
+            shouldFetchRemoteFlowHeaders({}, undefined, 'https://example.com/sub'),
+        ).to.equal(true);
+    });
+
+    it('respects noFlow and non-HTTP subscription URLs for remote flow headers', function () {
+        expect(
+            shouldFetchRemoteFlowHeaders(
+                { noFlow: true },
+                undefined,
+                'https://example.com/sub',
+            ),
+        ).to.equal(false);
+        expect(
+            shouldFetchRemoteFlowHeaders(
+                {},
+                undefined,
+                'ss://YWVzLTEyOC1nY206cGFzc3dvcmQ=',
+            ),
+        ).to.equal(false);
+    });
 });


### PR DESCRIPTION
当订阅已经手动配置了固定的 subUserinfo 流量信息时，下载订阅不再额外请求原始订阅地址获取流量响应头。
原逻辑会先对原始订阅 URL 发起 HEAD/GET 请求获取 subscription-userinfo，即使用户已经配置了固定流量信息。对于部分订阅源，这个额外请求可能超时，导致订阅下载整体变慢。新逻辑会在检测到非 URL 形式的固定 subUserinfo 时，跳过远程 flow header 请求，直接使用已配置的流量信息；URL 形式的自定义流量链接、未配置固定流量信息、noFlow 等场景保持原有行为不变。