### PR TITLE
修复格式转换后不能被正常识别的问题  就搞了我常用的三个 其他的没有看 

### DIFF
--- a/backend/src/core/proxy-utils/index.js
+++ b/backend/src/core/proxy-utils/index.js
@@ -549,6 +549,9 @@ function produce(proxies, targetPlatform, type, opts = {}) {
     });
 
     $.log(`Producing proxies for target: ${targetPlatform}`);
+    if (producer.produceAll && (type !== 'internal' || producer.type !== 'ALL')) {
+        return producer.produceAll(proxies, type, opts);
+    }
     if (typeof producer.type === 'undefined' || producer.type === 'SINGLE') {
         let list = proxies
             .map((proxy) => {
@@ -718,6 +721,60 @@ function formatTransportPath(path) {
     return path;
 }
 
+function normalizeHostnameValue(value) {
+    if (value == null || value === '') return value;
+    const raw = `${value}`.trim();
+    if (!raw || raw === 'off') return value;
+
+    const isValidHostname = (host) => {
+        const normalized = `${host || ''}`.trim().replace(/^\[/, '').replace(/\]$/, '');
+        return (
+            normalized.length > 0 &&
+            normalized.length <= 253 &&
+            !/^https?:\/\//i.test(normalized) &&
+            !/[\s/?#@()[\]]/.test(normalized) &&
+            (/^[A-Za-z0-9.-]+$/.test(normalized) || isIP(normalized))
+        );
+    };
+
+    const cleanHostname = (host) => `${host}`.trim().replace(/^\[/, '').replace(/\]$/, '');
+    const markdown = raw.match(/^\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)$/i);
+    if (markdown) {
+        if (isValidHostname(markdown[1])) return cleanHostname(markdown[1]);
+        try {
+            const host = new URL(markdown[2]).hostname;
+            if (isValidHostname(host)) return cleanHostname(host);
+        } catch (e) {
+            return undefined;
+        }
+        return undefined;
+    }
+
+    if (/^https?:\/\//i.test(raw)) {
+        try {
+            const host = new URL(raw).hostname;
+            if (isValidHostname(host)) return cleanHostname(host);
+        } catch (e) {
+            return undefined;
+        }
+        return undefined;
+    }
+
+    return value;
+}
+
+function normalizeProxySni(proxy) {
+    for (const key of ['sni', 'servername', 'peer']) {
+        if (!Object.prototype.hasOwnProperty.call(proxy, key)) continue;
+        const normalized = normalizeHostnameValue(proxy[key]);
+        if (normalized == null) {
+            delete proxy[key];
+        } else {
+            proxy[key] = normalized;
+        }
+    }
+}
+
 function lastParse(proxy) {
     proxy.udp = ![false, 0, '0', 'false', 'off'].includes(
         typeof proxy.udp === 'string' ? proxy.udp.toLowerCase() : proxy.udp,
@@ -781,6 +838,7 @@ function lastParse(proxy) {
             .replace(/^\[/, '')
             .replace(/\]$/, '');
     }
+    normalizeProxySni(proxy);
     if (
         ['vmess', 'vless', 'trojan', 'anytls'].includes(proxy.type) &&
         proxy['shadow-tls-opts']

--- a/backend/src/core/proxy-utils/preprocessors/index.js
+++ b/backend/src/core/proxy-utils/preprocessors/index.js
@@ -3,24 +3,41 @@ import { Base64 } from 'js-base64';
 import $ from '@/core/app';
 
 export function normalizeClashYaml(raw) {
+    if (typeof raw !== 'string') return raw;
+
+    const normalizedRaw = raw.replace(
+        /(^|[,\s{])((?:sni|servername|peer):)([ \t]*)\[([^\]\n]+)\]\((https?:\/\/[^\s)\n]+)\)/gim,
+        (matched, prefix, key, spacing, label, url) => {
+            const trimmedLabel = label.trim();
+            if (/^[A-Za-z0-9.-]+$/.test(trimmedLabel)) {
+                return `${prefix}${key}${spacing}${trimmedLabel}`;
+            }
+            try {
+                const host = new URL(url).hostname;
+                return `${prefix}${key}${spacing}${host || trimmedLabel}`;
+            } catch (e) {
+                return `${prefix}${key}${spacing}${trimmedLabel}`;
+            }
+        },
+    );
+
     if (
-        typeof raw !== 'string' ||
-        !raw.includes('proxies:') ||
-        !raw.includes('short-id:')
+        !normalizedRaw.includes('proxies:') ||
+        !normalizedRaw.includes('short-id:')
     ) {
-        return raw;
+        return normalizedRaw;
     }
 
     try {
-        const content = safeLoad(raw);
+        const content = safeLoad(normalizedRaw);
         if (!Array.isArray(content.proxies) || content.proxies.length === 0)
-            return raw;
+            return normalizedRaw;
     } catch (e) {
-        return raw;
+        return normalizedRaw;
     }
     // 防止 VLESS 节点 reality-opts 里的 short-id 被 YAML 标量推断成数字
     // 例如 08 / 0088 在部分内核重新解析时会触发 invalid REALITY short ID
-    return raw.replace(/short-id:([ \t]*[^#\n,}]*)/g, (matched, value) => {
+    return normalizedRaw.replace(/short-id:([ \t]*[^#\n,}]*)/g, (matched, value) => {
         const afterTrim = value.trim();
 
         if (!afterTrim || afterTrim === '') {
@@ -110,7 +127,7 @@ function Clash() {
     const name = 'Clash Pre-processor';
     const test = function (raw) {
         if (!/proxies/.test(raw)) return false;
-        const content = safeLoad(raw);
+        const content = safeLoad(normalizeClashYaml(raw));
         return (
             Array.isArray(content.proxies) ||
             Array.isArray(content['proxy-groups'])

--- a/backend/src/core/proxy-utils/producers/clash.js
+++ b/backend/src/core/proxy-utils/producers/clash.js
@@ -218,7 +218,7 @@ export default function Clash_Producer() {
                 }
                 return proxy;
             });
-        return produceProxyListOutput(list, type, opts);
+        return produceProxyListOutput(list, type, { ...opts, _clashProfile: true });
     };
     return { type, produce };
 }

--- a/backend/src/core/proxy-utils/producers/clashmeta.js
+++ b/backend/src/core/proxy-utils/producers/clashmeta.js
@@ -441,7 +441,7 @@ export default function ClashMeta_Producer() {
                 return proxy;
             });
 
-        return produceProxyListOutput(list, type, opts);
+        return produceProxyListOutput(list, type, { ...opts, _clashProfile: true });
     };
     return { type, produce };
 }

--- a/backend/src/core/proxy-utils/producers/sing-box.js
+++ b/backend/src/core/proxy-utils/producers/sing-box.js
@@ -108,8 +108,35 @@ const smuxParser = (smux, proxy) => {
     }
 };
 
+const normalizeHeaderValue = (value) => {
+    if (value === '') return undefined;
+    if (Array.isArray(value)) return value.map((item) => `${item}`).filter(Boolean);
+    return [`${value}`];
+};
+
+const mergeWsHeaders = (transport, wsHeaders = {}) => {
+    if (!wsHeaders || Object.keys(wsHeaders).length === 0) return;
+    const headers = {};
+    for (const key of Object.keys(wsHeaders)) {
+        const value = normalizeHeaderValue(wsHeaders[key]);
+        if (value?.length > 0) headers[key] = value;
+    }
+    const wsHost = headers.Host;
+    if (Array.isArray(wsHost) && wsHost.length === 1) {
+        for (const item of `Host:${wsHost[0]}`.split('\n')) {
+            const [key, ...rest] = item.split(':');
+            const value = rest.join(':');
+            if (!value || value.trim() === '') continue;
+            headers[key.trim()] = value.trim().split(',');
+        }
+    }
+    for (const key of Object.keys(headers)) {
+        transport.headers[key] = headers[key];
+    }
+};
+
 const wsParser = (proxy, parsedProxy) => {
-    const transport = { type: 'ws', headers: {} };
+    const transport = { type: 'ws', headers: {}, path: '/' };
     if (proxy['ws-opts']) {
         const {
             path: wsPath = '',
@@ -122,41 +149,10 @@ const wsParser = (proxy, parsedProxy) => {
             ? parseInt(max_early_data, 10)
             : undefined;
         if (wsPath !== '') transport.path = `${wsPath}`;
-        if (Object.keys(wsHeaders).length > 0) {
-            const headers = {};
-            for (const key of Object.keys(wsHeaders)) {
-                let value = wsHeaders[key];
-                if (value === '') continue;
-                if (!Array.isArray(value)) value = [`${value}`];
-                if (value.length > 0) headers[key] = value;
-            }
-            const { Host: wsHost } = headers;
-            if (wsHost.length === 1)
-                for (const item of `Host:${wsHost[0]}`.split('\n')) {
-                    const [key, value] = item.split(':');
-                    if (value.trim() === '') continue;
-                    headers[key.trim()] = value.trim().split(',');
-                }
-            transport.headers = headers;
-        }
+        mergeWsHeaders(transport, wsHeaders);
     }
     if (proxy['ws-headers']) {
-        const headers = {};
-        for (const key of Object.keys(proxy['ws-headers'])) {
-            let value = proxy['ws-headers'][key];
-            if (value === '') continue;
-            if (!Array.isArray(value)) value = [`${value}`];
-            if (value.length > 0) headers[key] = value;
-        }
-        const { Host: wsHost } = headers;
-        if (wsHost.length === 1)
-            for (const item of `Host:${wsHost[0]}`.split('\n')) {
-                const [key, value] = item.split(':');
-                if (value.trim() === '') continue;
-                headers[key.trim()] = value.trim().split(',');
-            }
-        for (const key of Object.keys(headers))
-            transport.headers[key] = headers[key];
+        mergeWsHeaders(transport, proxy['ws-headers']);
     }
     if (proxy['ws-path'] && proxy['ws-path'] !== '')
         transport.path = `${proxy['ws-path']}`;
@@ -170,11 +166,12 @@ const wsParser = (proxy, parsedProxy) => {
         }
     }
 
-    if (parsedProxy.tls.insecure)
-        parsedProxy.tls.server_name = transport.headers.Host[0];
+    const wsHost = transport.headers.Host;
+    if (parsedProxy.tls.insecure && Array.isArray(wsHost) && wsHost.length > 0)
+        parsedProxy.tls.server_name = wsHost[0];
     if (proxy['ws-opts'] && proxy['ws-opts']['v2ray-http-upgrade']) {
         transport.type = 'httpupgrade';
-        if (transport.headers.Host) {
+        if (Array.isArray(transport.headers.Host) && transport.headers.Host.length) {
             transport.host = transport.headers.Host[0];
             delete transport.headers.Host;
         }
@@ -1296,6 +1293,165 @@ const wireguardParser = (proxy = {}) => {
     return parsedProxy;
 };
 
+const SING_BOX_SELECTOR_TAG = '节点选择';
+const SING_BOX_URLTEST_TAG = '自动选择';
+const SING_BOX_DIRECT_TAG = 'DIRECT';
+
+function wantsSingBoxFragment(opts = {}) {
+    return Boolean(
+        opts.fragment ||
+            opts.outboundsOnly ||
+            opts['outbounds-only'] ||
+            opts.outboundOnly ||
+            opts['outbound-only'],
+    );
+}
+
+function getOutboundTags(outbounds = []) {
+    return outbounds.map((outbound) => outbound.tag).filter(Boolean);
+}
+
+function withDefaultDomainResolver(outbound) {
+    if (
+        outbound &&
+        outbound.type !== 'direct' &&
+        outbound.type !== 'selector' &&
+        outbound.type !== 'urltest' &&
+        !outbound.domain_resolver
+    ) {
+        outbound.domain_resolver = 'local';
+    }
+    return outbound;
+}
+
+function buildSingBoxConfig(categorized, opts = {}) {
+    const proxyTags = getOutboundTags(categorized.outbounds);
+    const selectableTags = proxyTags.length ? proxyTags : [SING_BOX_DIRECT_TAG];
+    const selectorTag = opts['selector-tag'] || opts.selectorTag || SING_BOX_SELECTOR_TAG;
+    const urltestTag = opts['urltest-tag'] || opts.urltestTag || SING_BOX_URLTEST_TAG;
+    const testUrl = opts['test-url'] || opts.testUrl || 'https://www.gstatic.com/generate_204';
+
+    return {
+        dns: {
+            servers: [
+                { type: 'local', tag: 'local' },
+                { type: 'udp', tag: 'remote', server: '1.1.1.1' },
+                { type: 'udp', tag: 'cn', server: '223.5.5.5' },
+            ],
+            rules: [{ rule_set: ['geosite-cn'], action: 'route', server: 'cn' }],
+            final: 'remote',
+        },
+        inbounds: [
+            {
+                tag: 'tun-in',
+                type: 'tun',
+                address: ['172.19.0.1/30', '2001:0470:f9da:fdfa::1/64'],
+                auto_route: true,
+                mtu: 9000,
+                stack: 'system',
+                strict_route: true,
+                route_exclude_address_set: ['geoip-cn'],
+            },
+            {
+                tag: 'socks-in',
+                type: 'socks',
+                listen: '127.0.0.1',
+                listen_port: Number(opts['socks-port'] || opts.socksPort) || 2333,
+                users: [],
+            },
+            {
+                tag: 'mixed-in',
+                type: 'mixed',
+                listen: '127.0.0.1',
+                listen_port: Number(opts['mixed-port'] || opts.mixedPort) || 2334,
+                users: [],
+            },
+        ],
+        outbounds: [
+            {
+                tag: SING_BOX_DIRECT_TAG,
+                type: 'direct',
+                domain_resolver: { server: 'local' },
+            },
+            {
+                tag: selectorTag,
+                type: 'selector',
+                interrupt_exist_connections: true,
+                outbounds: [urltestTag, ...selectableTags],
+            },
+            {
+                tag: urltestTag,
+                type: 'urltest',
+                url: testUrl,
+                interval: opts.interval || '10m',
+                tolerance: Number(opts.tolerance) || 50,
+                idle_timeout: opts['idle-timeout'] || opts.idleTimeout || '30m',
+                interrupt_exist_connections: false,
+                outbounds: selectableTags,
+            },
+            ...categorized.outbounds.map(withDefaultDomainResolver),
+        ],
+        endpoints: categorized.endpoints,
+        route: {
+            rules: [
+                { action: 'sniff' },
+                { protocol: 'dns', action: 'hijack-dns' },
+                {
+                    rule_set: ['category-ads-all'],
+                    action: 'reject',
+                    method: 'default',
+                    no_drop: false,
+                },
+                { ip_is_private: true, action: 'route', outbound: SING_BOX_DIRECT_TAG },
+                { clash_mode: '关闭代理', action: 'route', outbound: SING_BOX_DIRECT_TAG },
+                { clash_mode: '全局代理', action: 'route', outbound: selectorTag },
+                { rule_set: ['geosite-cn', 'geoip-cn'], action: 'route', outbound: SING_BOX_DIRECT_TAG },
+            ],
+            auto_detect_interface: true,
+            final: selectorTag,
+            default_domain_resolver: { server: 'remote' },
+            rule_set: [
+                {
+                    tag: 'geosite-geolocation-!cn',
+                    type: 'remote',
+                    format: 'binary',
+                    url: 'https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-geolocation-!cn.srs',
+                    download_detour: selectorTag,
+                },
+                {
+                    tag: 'geoip-cn',
+                    type: 'remote',
+                    format: 'binary',
+                    url: 'https://raw.githubusercontent.com/Loyalsoldier/geoip/release/srs/cn.srs',
+                    download_detour: selectorTag,
+                },
+                {
+                    tag: 'geosite-cn',
+                    type: 'remote',
+                    format: 'binary',
+                    url: 'https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-cn.srs',
+                    download_detour: selectorTag,
+                },
+                {
+                    tag: 'category-ads-all',
+                    type: 'remote',
+                    format: 'binary',
+                    url: 'https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set/geosite-category-ads-all.srs',
+                    download_detour: selectorTag,
+                },
+            ],
+        },
+        experimental: {
+            cache_file: { enabled: true },
+            clash_api: {
+                default_mode: '海外代理',
+                external_controller: opts['external-controller'] || '127.0.0.1:9090',
+                secret: opts.secret || '',
+            },
+        },
+    };
+}
+
 export default function singbox_Producer() {
     const type = 'ALL';
     const produce = (proxies, type, opts = {}) => {
@@ -1599,7 +1755,11 @@ export default function singbox_Producer() {
             { outbounds: [], endpoints: [] },
         );
 
-        return JSON.stringify(categorized, null, 2);
+        if (wantsSingBoxFragment(opts)) {
+            return JSON.stringify(categorized, null, 2);
+        }
+
+        return JSON.stringify(buildSingBoxConfig(categorized, opts), null, 2);
     };
     return { type, produce };
 }

--- a/backend/src/core/proxy-utils/producers/surfboard.js
+++ b/backend/src/core/proxy-utils/producers/surfboard.js
@@ -4,6 +4,60 @@ import { isNotBlank } from '@/utils';
 
 const targetPlatform = 'Surfboard';
 
+function sanitizeProfileName(name) {
+    return `${name}`.replace(/=|,|\r|\n/g, '').trim() || 'Proxy';
+}
+
+function cleanProfileValue(value) {
+    if (value == null) return value;
+    return `${value}`.replace(/[\r\n]/g, '');
+}
+
+function wantsSurfboardFragment(opts = {}) {
+    return Boolean(
+        opts.fragment ||
+            opts.proxyOnly ||
+            opts['proxy-only'] ||
+            opts.proxiesOnly ||
+            opts['proxies-only'],
+    );
+}
+
+function buildSurfboardProfile(lines, opts = {}) {
+    const proxyNames = lines
+        .map((line) => line.split('=')[0]?.trim())
+        .filter((name) => isNotBlank(name));
+    const proxyGroup = opts['proxy-group'] || opts.proxyGroup || '节点选择';
+    const autoGroup = opts['auto-group'] || opts.autoGroup || '自动选择';
+    const fallbackGroup = opts['fallback-group'] || opts.fallbackGroup || '故障转移';
+    const testUrl = opts['test-url'] || opts.testUrl || 'http://www.gstatic.com/generate_204';
+    const groupMembers = proxyNames.length ? proxyNames.join(', ') : 'DIRECT';
+
+    return [
+        '[General]',
+        'dns-server = system, 8.8.8.8, 8.8.4.4',
+        `proxy-test-url = ${testUrl}`,
+        'test-timeout = 5',
+        'ipv6 = false',
+        '',
+        '[Proxy]',
+        ...lines,
+        '',
+        '[Proxy Group]',
+        `${proxyGroup} = select, ${autoGroup}, DIRECT, REJECT${proxyNames.length ? `, ${groupMembers}` : ''}`,
+        `${autoGroup} = url-test, ${groupMembers}, url=${testUrl}, interval=600, tolerance=100, timeout=5`,
+        `${fallbackGroup} = fallback, ${groupMembers}, url=${testUrl}, interval=600, timeout=5`,
+        '',
+        '[Rule]',
+        'IP-CIDR,127.0.0.0/8,DIRECT',
+        'IP-CIDR,10.0.0.0/8,DIRECT',
+        'IP-CIDR,172.16.0.0/12,DIRECT',
+        'IP-CIDR,192.168.0.0/16,DIRECT',
+        'GEOIP,CN,DIRECT',
+        `FINAL,${proxyGroup}`,
+    ].join('\n');
+}
+
 function hasNonBlankValue(value) {
     return value != null && `${value}`.trim().length > 0;
 }
@@ -14,10 +68,10 @@ function appendTlsProxyParams(result, proxy, enabled = true) {
     }
 
     result.appendIfPresent(
-        `,server-cert-fingerprint-sha256=${proxy['tls-fingerprint']}`,
+        `,server-cert-fingerprint-sha256=${cleanProfileValue(proxy['tls-fingerprint'])}`,
         'tls-fingerprint',
     );
-    result.appendIfPresent(`,sni="${proxy.sni}"`, 'sni');
+    result.appendIfPresent(`,sni=${cleanProfileValue(proxy.sni)}`, 'sni');
     result.appendIfPresent(
         `,skip-cert-verify=${proxy['skip-cert-verify']}`,
         'skip-cert-verify',
@@ -34,7 +88,7 @@ export default function Surfboard_Producer() {
                 `Platform ${targetPlatform} does not support network ${proxy.network} with http upgrade`,
             );
         }
-        proxy.name = proxy.name.replace(/=|,/g, '');
+        proxy.name = sanitizeProfileName(proxy.name);
         switch (proxy.type) {
             case 'ss':
                 return shadowsocks(proxy);
@@ -72,7 +126,22 @@ export default function Surfboard_Producer() {
             `Platform ${targetPlatform} does not support proxy type: ${proxy.type}`,
         );
     };
-    return { produce };
+    const produceAll = (proxies, type, opts = {}) => {
+        const lines = proxies
+            .map((proxy) => {
+                try {
+                    return produce(proxy, type, opts);
+                } catch (err) {
+                    return '';
+                }
+            })
+            .filter((line) => line.length > 0);
+        if (type === 'internal') return lines;
+        if (wantsSurfboardFragment(opts)) return lines.join('\n');
+        if (lines.length === 0) return '';
+        return buildSurfboardProfile(lines, opts);
+    };
+    return { type: 'SINGLE', produce, produceAll };
 }
 function tuic(proxy) {
     if (proxy.token?.length) {
@@ -81,9 +150,9 @@ function tuic(proxy) {
         );
     }
     const result = new Result(proxy);
-    result.append(`${proxy.name}=tuic-v5,${proxy.server},${proxy.port}`);
-    result.appendIfPresent(`,uuid=${proxy.uuid}`, 'uuid');
-    result.appendIfPresent(`,password="${proxy.password}"`, 'password');
+    result.append(`${proxy.name}=tuic-v5,${cleanProfileValue(proxy.server)},${proxy.port}`);
+    result.appendIfPresent(`,uuid=${cleanProfileValue(proxy.uuid)}`, 'uuid');
+    result.appendIfPresent(`,password="${cleanProfileValue(proxy.password)}"`, 'password');
     if (hasNonBlankValue(proxy.alpn)) {
         result.append(
             `,alpn="${
@@ -112,9 +181,9 @@ function hysteria2(proxy) {
     }
 
     const result = new Result(proxy);
-    result.append(`${proxy.name}=hysteria2,${proxy.server},${proxy.port}`);
+    result.append(`${proxy.name}=hysteria2,${cleanProfileValue(proxy.server)},${proxy.port}`);
 
-    result.appendIfPresent(`,password="${proxy.password}"`, 'password');
+    result.appendIfPresent(`,password="${cleanProfileValue(proxy.password)}"`, 'password');
 
     if (hasNonBlankValue(proxy.ports)) {
         result.append(
@@ -127,7 +196,7 @@ function hysteria2(proxy) {
     }
 
     if (proxy['obfs-password']) {
-        result.append(`,salamander-password="${proxy['obfs-password']}"`);
+        result.append(`,salamander-password="${cleanProfileValue(proxy['obfs-password'])}"`);
     }
 
     // tls verification
@@ -148,8 +217,10 @@ function hysteria2(proxy) {
 }
 function anytls(proxy) {
     const result = new Result(proxy);
-    result.append(`${proxy.name}=${proxy.type},${proxy.server},${proxy.port}`);
-    result.appendIfPresent(`,password="${proxy.password}"`, 'password');
+    result.append(`${proxy.name}=${proxy.type},${cleanProfileValue(proxy.server)},${proxy.port}`);
+    if (isPresent(proxy, 'password')) {
+        result.append(`,${cleanProfileValue(proxy.password)}`);
+    }
 
     // tls verification
     appendTlsProxyParams(result, proxy);
@@ -177,9 +248,9 @@ function snell(proxy) {
         );
     }
     const result = new Result(proxy);
-    result.append(`${proxy.name}=${proxy.type},${proxy.server},${proxy.port}`);
+    result.append(`${proxy.name}=${proxy.type},${cleanProfileValue(proxy.server)},${proxy.port}`);
     result.appendIfPresent(`,version=${proxy.version}`, 'version');
-    result.appendIfPresent(`,psk="${proxy.psk}"`, 'psk');
+    result.appendIfPresent(`,psk="${cleanProfileValue(proxy.psk)}"`, 'psk');
 
     // obfs
     result.appendIfPresent(
@@ -209,7 +280,7 @@ function snell(proxy) {
 }
 function shadowsocks(proxy) {
     const result = new Result(proxy);
-    result.append(`${proxy.name}=${proxy.type},${proxy.server},${proxy.port}`);
+    result.append(`${proxy.name}=${proxy.type},${cleanProfileValue(proxy.server)},${proxy.port}`);
     if (
         ![
             'aes-128-gcm',
@@ -239,7 +310,7 @@ function shadowsocks(proxy) {
         throw new Error(`cipher ${proxy.cipher} is not supported`);
     }
     result.append(`,encrypt-method=${proxy.cipher}`);
-    result.appendIfPresent(`,password="${proxy.password}"`, 'password');
+    result.appendIfPresent(`,password="${cleanProfileValue(proxy.password)}"`, 'password');
 
     // obfs
     if (isPresent(proxy, 'plugin')) {
@@ -268,8 +339,8 @@ function shadowsocks(proxy) {
 
 function trojan(proxy) {
     const result = new Result(proxy);
-    result.append(`${proxy.name}=${proxy.type},${proxy.server},${proxy.port}`);
-    result.appendIfPresent(`,password=${proxy.password}`, 'password');
+    result.append(`${proxy.name}=${proxy.type},${cleanProfileValue(proxy.server)},${proxy.port}`);
+    result.appendIfPresent(`,password=${cleanProfileValue(proxy.password)}`, 'password');
 
     // transport
     handleTransport(result, proxy);
@@ -293,7 +364,7 @@ function trojan(proxy) {
 
 function vmess(proxy) {
     const result = new Result(proxy);
-    result.append(`${proxy.name}=${proxy.type},${proxy.server},${proxy.port}`);
+    result.append(`${proxy.name}=${proxy.type},${cleanProfileValue(proxy.server)},${proxy.port}`);
     result.appendIfPresent(`,username=${proxy.uuid}`, 'uuid');
 
     // transport
@@ -323,9 +394,9 @@ function vmess(proxy) {
 function http(proxy) {
     const result = new Result(proxy);
     const type = proxy.tls ? 'https' : 'http';
-    result.append(`${proxy.name}=${type},${proxy.server},${proxy.port}`);
-    result.appendIfPresent(`,${proxy.username}`, 'username');
-    result.appendIfPresent(`,${proxy.password}`, 'password');
+    result.append(`${proxy.name}=${type},${cleanProfileValue(proxy.server)},${proxy.port}`);
+    result.appendIfPresent(`,${cleanProfileValue(proxy.username)}`, 'username');
+    result.appendIfPresent(`,${cleanProfileValue(proxy.password)}`, 'password');
 
     // tls verification
     appendTlsProxyParams(result, proxy, Boolean(proxy.tls));
@@ -341,9 +412,9 @@ function http(proxy) {
 function socks5(proxy) {
     const result = new Result(proxy);
     const type = proxy.tls ? 'socks5-tls' : 'socks5';
-    result.append(`${proxy.name}=${type},${proxy.server},${proxy.port}`);
-    result.appendIfPresent(`,${proxy.username}`, 'username');
-    result.appendIfPresent(`,${proxy.password}`, 'password');
+    result.append(`${proxy.name}=${type},${cleanProfileValue(proxy.server)},${proxy.port}`);
+    result.appendIfPresent(`,${cleanProfileValue(proxy.username)}`, 'username');
+    result.appendIfPresent(`,${cleanProfileValue(proxy.password)}`, 'password');
 
     // tls verification
     appendTlsProxyParams(result, proxy, Boolean(proxy.tls));
@@ -375,25 +446,21 @@ function handleTransport(result, proxy) {
     if (isPresent(proxy, 'network')) {
         if (proxy.network === 'ws') {
             result.append(`,ws=true`);
-            if (isPresent(proxy, 'ws-opts')) {
-                result.appendIfPresent(
-                    `,ws-path=${proxy['ws-opts'].path}`,
-                    'ws-opts.path',
-                );
-                if (isPresent(proxy, 'ws-opts.headers')) {
-                    const headers = proxy['ws-opts'].headers;
-                    const value = Object.keys(headers)
-                        .map((k) => {
-                            let v = headers[k];
-                            if (['Host'].includes(k)) {
-                                v = `"${v}"`;
-                            }
-                            return `${k}:${v}`;
-                        })
-                        .join('|');
-                    if (isNotBlank(value)) {
-                        result.append(`,ws-headers=${value}`);
-                    }
+            const wsOpts = proxy['ws-opts'] || {};
+            result.append(`,ws-path=${cleanProfileValue(wsOpts.path || '/')}`);
+            if (isPresent(proxy, 'ws-opts.headers')) {
+                const headers = proxy['ws-opts'].headers;
+                const value = Object.keys(headers)
+                    .map((k) => {
+                        const v = headers[k];
+                        if (Array.isArray(v)) {
+                            return `${cleanProfileValue(k)}:${v.map(cleanProfileValue).join(',')}`;
+                        }
+                        return `${cleanProfileValue(k)}:${cleanProfileValue(v)}`;
+                    })
+                    .join('|');
+                if (isNotBlank(value)) {
+                    result.append(`,ws-headers=${value}`);
                 }
             }
         } else if (['tcp'].includes(proxy.network) && proxy['reality-opts']) {

--- a/backend/src/core/proxy-utils/producers/utils.js
+++ b/backend/src/core/proxy-utils/producers/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import YAML from '@/utils/yaml';
-import { isIPv4, isIPv6 } from '@/utils';
+import { isIPv4, isIPv6, isNotBlank } from '@/utils';
 import { normalizeClashYaml } from '@/core/proxy-utils/preprocessors';
 
 export class Result {
@@ -184,24 +184,123 @@ export function getWireGuardAddressWithCIDR(proxy = {}, family = 'ipv4') {
     }`;
 }
 
+const DEFAULT_CLASH_PROXY_GROUP = '节点选择';
+const DEFAULT_CLASH_AUTO_GROUP = '自动选择';
+const DEFAULT_CLASH_FALLBACK_GROUP = '故障转移';
+
+function wantsProxyListFragment(opts = {}) {
+    return Boolean(
+        opts.fragment ||
+            opts['proxy-provider'] ||
+            opts.proxyProvider ||
+            opts.proxiesOnly ||
+            opts['proxies-only'],
+    );
+}
+
+function getProxyNames(list = []) {
+    return list.map((proxy) => proxy.name).filter((name) => isNotBlank(name));
+}
+
+function produceClashProxyListOutput(list) {
+    return normalizeClashYaml(
+        YAML.safeDump(
+            {
+                proxies: list,
+            },
+            {
+                lineWidth: -1,
+            },
+        ),
+    );
+}
+
+export function produceClashProfileOutput(list, opts = {}) {
+    const proxyGroup = opts['proxy-group'] || opts.proxyGroup || DEFAULT_CLASH_PROXY_GROUP;
+    const autoGroup = opts['auto-group'] || opts.autoGroup || DEFAULT_CLASH_AUTO_GROUP;
+    const fallbackGroup =
+        opts['fallback-group'] || opts.fallbackGroup || DEFAULT_CLASH_FALLBACK_GROUP;
+    const testUrl = opts['test-url'] || opts.testUrl || 'http://www.gstatic.com/generate_204';
+    const proxyNames = getProxyNames(list);
+    const selectable = [autoGroup, fallbackGroup, ...proxyNames];
+    const fullConfig = {
+        'mixed-port': Number(opts['mixed-port'] || opts.mixedPort) || 7890,
+        'allow-lan': opts['allow-lan'] ?? opts.allowLan ?? true,
+        'bind-address': opts['bind-address'] || opts.bindAddress || '*',
+        mode: opts.mode || 'rule',
+        'log-level': opts['log-level'] || opts.logLevel || 'info',
+        'external-controller':
+            opts['external-controller'] || opts.externalController || '127.0.0.1:9090',
+        dns: {
+            enable: true,
+            ipv6: false,
+            'default-nameserver': ['223.5.5.5', '119.29.29.29', '114.114.114.114'],
+            'enhanced-mode': 'fake-ip',
+            'fake-ip-range': '198.18.0.1/16',
+            'use-hosts': true,
+            'respect-rules': true,
+            'proxy-server-nameserver': ['223.5.5.5', '119.29.29.29', '114.114.114.114'],
+            nameserver: ['223.5.5.5', '119.29.29.29', '114.114.114.114'],
+            fallback: ['1.1.1.1', '8.8.8.8'],
+            'fallback-filter': {
+                geoip: true,
+                'geoip-code': 'CN',
+                geosite: ['gfw'],
+                ipcidr: ['240.0.0.0/4'],
+                domain: ['+.google.com', '+.facebook.com', '+.youtube.com'],
+            },
+        },
+        proxies: list,
+        'proxy-groups': [
+            {
+                name: proxyGroup,
+                type: 'select',
+                proxies: selectable,
+            },
+            {
+                name: autoGroup,
+                type: 'url-test',
+                proxies: proxyNames,
+                url: testUrl,
+                interval: Number(opts['test-interval'] || opts.testInterval) || 600,
+            },
+            {
+                name: fallbackGroup,
+                type: 'fallback',
+                proxies: proxyNames,
+                url: testUrl,
+                interval: Number(opts['fallback-interval'] || opts.fallbackInterval) || 600,
+            },
+        ],
+        rules: [
+            'DOMAIN-KEYWORD,adservice,REJECT',
+            'DOMAIN-SUFFIX,doubleclick.net,REJECT',
+            'IP-CIDR,127.0.0.0/8,DIRECT',
+            'IP-CIDR,10.0.0.0/8,DIRECT',
+            'IP-CIDR,172.16.0.0/12,DIRECT',
+            'IP-CIDR,192.168.0.0/16,DIRECT',
+            'IP-CIDR,100.64.0.0/10,DIRECT',
+            'DOMAIN-SUFFIX,cn,DIRECT',
+            'GEOIP,CN,DIRECT',
+            `MATCH,${proxyGroup}`,
+        ],
+    };
+
+    if (proxyNames.length === 0) {
+        fullConfig['proxy-groups'][0].proxies = ['DIRECT'];
+        fullConfig['proxy-groups'][1].proxies = ['DIRECT'];
+        fullConfig['proxy-groups'][2].proxies = ['DIRECT'];
+    }
+
+    return normalizeClashYaml(YAML.safeDump(fullConfig, { lineWidth: -1 }));
+}
+
 export function produceProxyListOutput(list, type, opts = {}) {
     if (type === 'internal') return list;
 
-    if (opts.prettyYaml || opts['pretty-yaml']) {
-        return normalizeClashYaml(
-            YAML.safeDump(
-                {
-                    proxies: list,
-                },
-                {
-                    lineWidth: -1,
-                },
-            ),
-        );
+    if (wantsProxyListFragment(opts) || !opts._clashProfile) {
+        return produceClashProxyListOutput(list);
     }
 
-    return (
-        'proxies:\n' +
-        list.map((proxy) => '  - ' + JSON.stringify(proxy) + '\n').join('')
-    );
+    return produceClashProfileOutput(list, opts);
 }

--- a/backend/src/test/proxy-preprocessors/preprocessors.spec.js
+++ b/backend/src/test/proxy-preprocessors/preprocessors.spec.js
@@ -47,6 +47,21 @@ describe('Proxy preprocessors', function () {
             expect(output).to.include('short-id: null');
         });
 
+        it('normalizes unquoted markdown SNI before parsing Clash YAML', function () {
+            const raw = `proxies:
+  - name: AnyTLS
+    type: anytls
+    server: anytls.example.com
+    port: 443
+    password: secret
+    sni: [www.samsung.com](https://www.samsung.com)
+`;
+
+            const output = normalizeClashYaml(raw);
+
+            expect(output).to.include('sni: www.samsung.com');
+        });
+
         it('keeps non-clash or invalid yaml input untouched', function () {
             const invalid = 'proxies:\n  - name: broken\n    short-id: [';
             const unrelated = 'ss://YWVzLTEyOC1nY206c2VjcmV0@example.com:8388';
@@ -173,7 +188,7 @@ proxy-groups:
             expect(output).to.include('"name":"Clash SS"');
             expect(output).to.include('"name":"Clash VLESS"');
             expect(output).to.include('"short-id":"08"');
-            expect(wrapped).to.match(/^proxies:\n  - /);
+            expect(wrapped).to.match(/^proxies:\n {2}- /);
         });
     });
 

--- a/backend/src/test/proxy-producers/helpers.js
+++ b/backend/src/test/proxy-producers/helpers.js
@@ -22,6 +22,40 @@ export function produceExternal(platform, proxies, opts = {}) {
         clone(asList(proxies)),
         platform,
         'external',
+        withLegacyFragmentDefault(platform, opts),
+    );
+    expect(output, platform).to.be.a('string').and.not.equal('');
+    return output;
+}
+
+function withLegacyFragmentDefault(platform, opts = {}) {
+    if (Object.prototype.hasOwnProperty.call(opts, 'fragment')) return opts;
+    const normalized = `${platform}`.toLowerCase();
+    if (
+        [
+            'clash',
+            'mihomo',
+            'meta',
+            'clashmeta',
+            'clash.meta',
+            'stash',
+            'egern',
+            'shadowrocket',
+            'sing-box',
+            'singbox',
+            'surfboard',
+        ].includes(normalized)
+    ) {
+        return { ...opts, fragment: true };
+    }
+    return opts;
+}
+
+export function produceDefaultExternal(platform, proxies, opts = {}) {
+    const output = ProxyUtils.produce(
+        clone(asList(proxies)),
+        platform,
+        'external',
         opts,
     );
     expect(output, platform).to.be.a('string').and.not.equal('');
@@ -34,6 +68,10 @@ export function loadProducedYaml(platform, proxies, opts = {}) {
 
 export function loadProducedJson(platform, proxies, opts = {}) {
     return JSON.parse(produceExternal(platform, proxies, opts));
+}
+
+export function loadDefaultProducedJson(platform, proxies, opts = {}) {
+    return JSON.parse(produceDefaultExternal(platform, proxies, opts));
 }
 
 export function expectSubset(actual, expected, path = 'value') {

--- a/backend/src/test/proxy-producers/structured.spec.js
+++ b/backend/src/test/proxy-producers/structured.spec.js
@@ -6,8 +6,10 @@ import { ProxyUtils } from '@/core/proxy-utils';
 import {
     UUID,
     expectSubset,
+    loadDefaultProducedJson,
     loadProducedJson,
     loadProducedYaml,
+    produceDefaultExternal,
     produceExternal,
     produceInternal,
 } from './helpers';
@@ -37,6 +39,116 @@ function captureErrors(fn) {
 }
 
 describe('Proxy structured producers', function () {
+    it('emits full Clash-family profiles by default', function () {
+        const output = produceDefaultExternal('Mihomo', {
+            type: 'ss',
+            name: 'HK01',
+            server: 'ss.example.com',
+            port: 8388,
+            cipher: 'chacha20-ietf-poly1305',
+            password: 'secret',
+        });
+        const parsed = ProxyUtils.yaml.safeLoad(output);
+
+        expect(output).to.not.include('- {"name"');
+        expect(parsed['mixed-port']).to.equal(7890);
+        expect(parsed.proxies[0]).to.include({
+            name: 'HK01',
+            type: 'ss',
+            server: 'ss.example.com',
+        });
+        expect(parsed['proxy-groups'].map((group) => group.name)).to.include.members([
+            '节点选择',
+            '自动选择',
+            '故障转移',
+        ]);
+        expect(parsed.rules.at(-1)).to.equal('MATCH,节点选择');
+    });
+
+    it('normalizes Markdown SNI and emits full sing-box profiles by default', function () {
+        const raw = `
+proxies:
+  - { name: Trojan WS, type: trojan, server: trojan.example.com, port: 443, password: secret, udp: true, network: ws, sni: "[www.samsung.com](https://www.samsung.com)", skip-cert-verify: false }
+  - { name: AnyTLS, type: anytls, server: anytls.example.com, port: 443, password: secret, client-fingerprint: chrome, udp: true, alpn: [h2, http/1.1], sni: "[www.samsung.com](https://www.samsung.com)", skip-cert-verify: true }
+  - { name: SS, type: ss, server: ss.example.com, port: 8388, cipher: chacha20-ietf-poly1305, password: secret, udp: true }
+`;
+        const proxies = ProxyUtils.parse(raw);
+        expect(proxies.map((proxy) => proxy.sni).filter(Boolean)).to.deep.equal([
+            'www.samsung.com',
+            'www.samsung.com',
+        ]);
+
+        const clash = produceDefaultExternal('Mihomo', proxies);
+        expect(clash).to.not.include('[www.samsung.com](https://www.samsung.com)');
+        expect(ProxyUtils.yaml.safeLoad(clash).proxies).to.have.length(3);
+
+        const singbox = loadDefaultProducedJson('sing-box', proxies);
+        expect(singbox).to.have.property('dns');
+        expect(singbox).to.have.property('inbounds');
+        expect(singbox).to.have.property('route');
+        expect(singbox.experimental.clash_api.external_controller).to.equal(
+            '127.0.0.1:9090',
+        );
+        const selector = singbox.outbounds.find((item) => item.tag === '节点选择');
+        const urltest = singbox.outbounds.find((item) => item.tag === '自动选择');
+        const trojan = singbox.outbounds.find((item) => item.tag === 'Trojan WS');
+        const anytls = singbox.outbounds.find((item) => item.tag === 'AnyTLS');
+
+        expect(selector.outbounds).to.include.members(['自动选择', 'Trojan WS', 'AnyTLS', 'SS']);
+        expect(urltest.outbounds).to.include.members(['Trojan WS', 'AnyTLS', 'SS']);
+        expectSubset(trojan, {
+            type: 'trojan',
+            tls: { server_name: 'www.samsung.com' },
+            transport: { type: 'ws', path: '/' },
+        });
+        expect(anytls.tls.server_name).to.equal('www.samsung.com');
+        expect(anytls.domain_resolver).to.equal('local');
+    });
+
+    it('keeps legacy sing-box fragments when fragment is requested', function () {
+        const output = loadProducedJson('sing-box', {
+            type: 'ss',
+            name: 'SS',
+            server: 'ss.example.com',
+            port: 8388,
+            cipher: 'chacha20-ietf-poly1305',
+            password: 'secret',
+        });
+
+        expect(output).to.have.keys(['outbounds', 'endpoints']);
+        expect(output.outbounds[0].tag).to.equal('SS');
+    });
+
+    it('keeps sing-box websocket nodes without Host headers', function () {
+        const output = loadDefaultProducedJson('sing-box', {
+            type: 'trojan',
+            name: 'Trojan Header',
+            server: 'trojan.example.com',
+            port: 443,
+            password: 'secret',
+            tls: true,
+            network: 'ws',
+            'skip-cert-verify': true,
+            'ws-opts': {
+                headers: {
+                    'X-Test': '1',
+                },
+            },
+        });
+        const trojan = output.outbounds.find((item) => item.tag === 'Trojan Header');
+
+        expectSubset(trojan, {
+            tls: { server_name: 'trojan.example.com', insecure: true },
+            transport: {
+                type: 'ws',
+                path: '/',
+                headers: {
+                    'X-Test': '1',
+                },
+            },
+        });
+    });
+
     it('filters unsupported Clash proxies by default and normalizes vmess ws early data', function () {
         const proxies = [
             {

--- a/backend/src/test/proxy-producers/text.spec.js
+++ b/backend/src/test/proxy-producers/text.spec.js
@@ -5,7 +5,7 @@ import { describe, it } from 'mocha';
 import $ from '@/core/app';
 import { ProxyUtils } from '@/core/proxy-utils';
 import QX_Producer from '@/core/proxy-utils/producers/qx';
-import { produceExternal, UUID } from './helpers';
+import { produceDefaultExternal, produceExternal, UUID } from './helpers';
 
 function captureWarns(fn) {
     const originalWarn = $.warn;
@@ -1607,6 +1607,75 @@ describe('Proxy text producers', function () {
         expect(output).to.not.include('ipv6-cidr');
     });
 
+    it('emits full Surfboard profiles by default', function () {
+        const output = produceDefaultExternal('Surfboard', [
+            {
+                type: 'trojan',
+                name: 'Trojan WS',
+                server: 'trojan.example.com',
+                port: 443,
+                password: 'secret',
+                network: 'ws',
+                tls: true,
+                sni: 'sni.example.com',
+            },
+            {
+                type: 'anytls',
+                name: 'AnyTLS',
+                server: 'anytls.example.com',
+                port: 443,
+                password: 'secret',
+                sni: 'anytls.example.com',
+                reuse: false,
+            },
+            {
+                type: 'ss',
+                name: 'SS',
+                server: 'ss.example.com',
+                port: 8388,
+                cipher: 'chacha20-ietf-poly1305',
+                password: 'secret',
+            },
+        ]);
+
+        expect(output).to.include('[General]');
+        expect(output).to.include('[Proxy]');
+        expect(output).to.include('[Proxy Group]');
+        expect(output).to.include('[Rule]');
+        expect(output).to.include(
+            'Trojan WS=trojan,trojan.example.com,443,password=secret,ws=true,ws-path=/,tls=true,sni=sni.example.com',
+        );
+        expect(output).to.include(
+            'AnyTLS=anytls,anytls.example.com,443,secret,sni=anytls.example.com,reuse=false',
+        );
+        expect(output).to.include('节点选择 = select, 自动选择, DIRECT, REJECT, Trojan WS, AnyTLS, SS');
+        expect(output).to.include('FINAL,节点选择');
+    });
+
+    it('sanitizes Surfboard profile names and newlines', function () {
+        const output = produceDefaultExternal('Surfboard', {
+            type: 'trojan',
+            name: 'Bad=Name,\nInjected',
+            server: 'trojan.example.com',
+            port: 443,
+            password: 'sec\nret',
+            network: 'ws',
+            tls: true,
+            sni: 'sni.example.com',
+            'ws-opts': {
+                headers: {
+                    Host: 'cdn.example.com',
+                    'X-Test': 'a\nb',
+                },
+            },
+        });
+
+        expect(output).to.include('BadNameInjected=trojan');
+        expect(output).to.include('password=secret');
+        expect(output).to.include('ws-headers=Host:cdn.example.com|X-Test:ab');
+        expect(output).to.not.include('sec\nret');
+    });
+
     it('produces Surfboard trojan websocket lines', function () {
         const output = produceExternal('Surfboard', {
             type: 'trojan',
@@ -1626,7 +1695,7 @@ describe('Proxy text producers', function () {
         });
 
         expect(output).to.equal(
-            'Trojan=trojan,trojan.example.com,443,password=secret,ws=true,ws-path=/ws,ws-headers=Host:"cdn.example.com",tls=true,sni="sni.example.com"',
+            'Trojan=trojan,trojan.example.com,443,password=secret,ws=true,ws-path=/ws,ws-headers=Host:cdn.example.com,tls=true,sni=sni.example.com',
         );
     });
 
@@ -1646,7 +1715,7 @@ describe('Proxy text producers', function () {
         });
 
         expect(output).to.equal(
-            'Surfboard Hysteria2=hysteria2,hy2.example.com,443,password="secret",port-hopping="8443;8445-8447",port-hopping-interval=30,sni="peer.example.com",skip-cert-verify=true,download-bandwidth=100,udp-relay=true',
+            'Surfboard Hysteria2=hysteria2,hy2.example.com,443,password="secret",port-hopping="8443;8445-8447",port-hopping-interval=30,sni=peer.example.com,skip-cert-verify=true,download-bandwidth=100,udp-relay=true',
         );
     });
 
@@ -1669,7 +1738,7 @@ describe('Proxy text producers', function () {
         });
 
         expect(output).to.equal(
-            `ProxyTuic=tuic-v5,1.2.3.4,443,uuid=${UUID},password="pwd",alpn="h3",port-hopping="1234;5000-6000",port-hopping-interval=30,server-cert-fingerprint-sha256=fac26f65c034829da42d740d23c4a7202475a3834f0ebaecae5f934adbbfd640,sni="example.com",skip-cert-verify=true,udp-relay=true`,
+            `ProxyTuic=tuic-v5,1.2.3.4,443,uuid=${UUID},password="pwd",alpn="h3",port-hopping="1234;5000-6000",port-hopping-interval=30,server-cert-fingerprint-sha256=fac26f65c034829da42d740d23c4a7202475a3834f0ebaecae5f934adbbfd640,sni=example.com,skip-cert-verify=true,udp-relay=true`,
         );
     });
 
@@ -1705,7 +1774,7 @@ describe('Proxy text producers', function () {
         });
 
         expect(output).to.equal(
-            'Surfboard Hysteria2 Plain=hysteria2,hy2.example.com,443,password="secret",sni="peer.example.com",skip-cert-verify=true',
+            'Surfboard Hysteria2 Plain=hysteria2,hy2.example.com,443,password="secret",sni=peer.example.com,skip-cert-verify=true',
         );
     });
 


### PR DESCRIPTION
…ard 这种需要一次性包装完整 profile 的 producer。

用户示例里 sni: [www.samsung.com](https://www.samsung.com) 如果不加引号，YAML 解析会直接失败。这个改动让它在解析前先变成合法 hostname。 让 Clash 目标默认走完整 profile 输出，而不是旧的纯节点列表。
让 Mihomo / ClashMeta / Clash.Meta 默认输出完整可导入 YAML。
解决 sing-box 只输出出站片段、不能直接导入使用的问题，并避免 Trojan/VMess/VLESS WS 节点因缺少 Host header 被丢弃。旧片段模式仍可用 fragment / outboundsOnly。 解决 Surfboard 不能只导入裸代理行的问题，使输出符合官方文档的 Surge 风格 profile。旧裸代理行模式仍可用 fragment / proxyOnly。 解决移动端 Clash 不能识别只有 proxies: 且节点是内联 JSON map 的问题。现在默认更接近可直接导入的 Clash/Mihomo 配置。 确保用户示例那种 sni: [www.samsung.com](https://www.samsung.com) 在进入 YAML parser 前能被修正 让旧测试继续验证片段输出，同时新测试可以明确验证“默认外部输出”的完整配置行为
覆盖用户反馈的核心问题，防止以后又退回到不可导入的片段格式或无效 SNI。
验证 Surfboard 默认输出包含官方 section，并且节点行不会因为非法字符或缺省 WS path 变成不可解析。