### PR TITLE
fix(SurgeMac): 合并 mihomo 配置覆盖层一次, 避免 GLOBAL 出现重复节点

### DIFF
--- a/backend/src/core/proxy-utils/index.js
+++ b/backend/src/core/proxy-utils/index.js
@@ -598,6 +598,7 @@ function produce(proxies, targetPlatform, type, opts = {}) {
                             Base64.encode(
                                 JSON.stringify({
                                     ...opts._merged.config,
+                                    ...(opts._merged.configOverride || {}),
                                     'mixed-port': opts.localPort,
                                 }),
                             ),

--- a/backend/src/core/proxy-utils/producers/surgemac.js
+++ b/backend/src/core/proxy-utils/producers/surgemac.js
@@ -211,7 +211,10 @@ function mihomo(proxy, type, opts) {
             // `proxy-groups[0].proxies.push()` 的目标, 使 GLOBAL 出现重复项.
             const configOverride = opts?.config || proxy._config;
             if (configOverride) {
-                opts._merged.configOverride = configOverride;
+                opts._merged.configOverride = {
+                    ...(opts._merged.configOverride || {}),
+                    ...configOverride,
+                };
             }
         } else {
             const external_proxy = {

--- a/backend/src/core/proxy-utils/producers/surgemac.js
+++ b/backend/src/core/proxy-utils/producers/surgemac.js
@@ -206,10 +206,13 @@ function mihomo(proxy, type, opts) {
                 ...clashProxy,
                 name: proxyName,
             });
-            opts._merged.config = {
-                ...opts._merged.config,
-                ...(opts?.config || proxy._config || {}),
-            };
+            // 只记录覆盖层, 在所有节点都并入后由 index.js 统一合并一次.
+            // 若在这里就合并, 覆盖层里的 proxy-groups 会成为后续节点
+            // `proxy-groups[0].proxies.push()` 的目标, 使 GLOBAL 出现重复项.
+            const configOverride = opts?.config || proxy._config;
+            if (configOverride) {
+                opts._merged.configOverride = configOverride;
+            }
         } else {
             const external_proxy = {
                 name: proxy.name,

--- a/backend/src/test/proxy-producers/text.spec.js
+++ b/backend/src/test/proxy-producers/text.spec.js
@@ -2111,6 +2111,28 @@ describe('Proxy text producers', function () {
         expect(config['mixed-port']).to.equal(19997);
     });
 
+    it('keeps earlier SurgeMac _config fields when later nodes add partial overrides', function () {
+        const overrides = [{ 'allow-lan': true }, { 'log-level': 'debug' }, {}];
+        const proxies = ['A', 'B', 'C'].map((name, index) => ({
+            type: 'trojan',
+            name,
+            server: `${name.toLowerCase()}.example.com`,
+            port: 443,
+            password: 'secret',
+            _merge: true,
+            _mihomoExternal: true,
+            _localPort: 20000,
+            _config: overrides[index],
+        }));
+
+        const output = ProxyUtils.produce(proxies, 'SurgeMac', 'external', {});
+        const args = [...output.matchAll(/args="([^"]+)"/g)].map((m) => m[1]);
+        const config = JSON.parse(Base64.decode(args[args.length - 1]));
+
+        expect(config['allow-lan']).to.equal(true);
+        expect(config['log-level']).to.equal('debug');
+    });
+
     it('produces URI WireGuard links with stored and default CIDR suffixes', function () {
         const output = produceExternal('URI', [
             {

--- a/backend/src/test/proxy-producers/text.spec.js
+++ b/backend/src/test/proxy-producers/text.spec.js
@@ -2067,6 +2067,50 @@ describe('Proxy text producers', function () {
         expect(output).to.not.include('Forced Mihomo=tuic-v5');
     });
 
+    it('merges SurgeMac _config once so GLOBAL lists each merged node once', function () {
+        // A Script Operator naturally builds the override once and assigns the
+        // same object to every node, so the shared reference must survive.
+        const override = {
+            'proxy-groups': [
+                {
+                    name: 'GLOBAL',
+                    type: 'fallback',
+                    proxies: ['20000', '19999', '19998'],
+                    url: 'http://cp.cloudflare.com/generate_204',
+                    interval: 300,
+                },
+            ],
+        };
+        const proxies = ['A', 'B', 'C'].map((name) => ({
+            type: 'trojan',
+            name,
+            server: `${name.toLowerCase()}.example.com`,
+            port: 443,
+            password: 'secret',
+            _merge: true,
+            _mihomoExternal: true,
+            _localPort: 20000,
+            _config: override,
+        }));
+
+        const output = ProxyUtils.produce(proxies, 'SurgeMac', 'external', {});
+
+        const args = [...output.matchAll(/args="([^"]+)"/g)].map((m) => m[1]);
+        const config = JSON.parse(Base64.decode(args[args.length - 1]));
+        const globalGroup = config['proxy-groups'].find(
+            (group) => group.name === 'GLOBAL',
+        );
+
+        expect(globalGroup.proxies).to.deep.equal(['20000', '19999', '19998']);
+        expect(globalGroup.url).to.equal(
+            'http://cp.cloudflare.com/generate_204',
+        );
+        expect(globalGroup.interval).to.equal(300);
+        expect(config.listeners).to.have.lengthOf(3);
+        expect(config.proxies).to.have.lengthOf(3);
+        expect(config['mixed-port']).to.equal(19997);
+    });
+
     it('produces URI WireGuard links with stored and default CIDR suffixes', function () {
         const output = produceExternal('URI', [
             {


### PR DESCRIPTION
## 问题

`_config`（节点字段）/ `opts.config`（URL query）是整份 mihomo 配置的覆盖层，但目前在 producer 的**逐节点循环内**做浅合并：

https://github.com/sub-store-org/Sub-Store/blob/master/backend/src/core/proxy-utils/producers/surgemac.js#L204-L212

```js
opts._merged.config["proxy-groups"][0].proxies.push(proxyName);   // 累积 GLOBAL 成员
opts._merged.config.proxies.push({ ...clashProxy, name: proxyName });
opts._merged.config = {
    ...opts._merged.config,
    ...(opts?.config || proxy._config || {}),                     // 覆盖层在这里并入
};
```

覆盖层一旦并入，它内部的 `proxy-groups` 数组就成了**后续节点** `push()` 的目标。而 Script Operator 最自然的写法是在 `map` 外构造一次覆盖层、再把同一个对象赋给每个节点，于是这个共享数组被反复追加。

3 个节点 + 覆盖 GLOBAL（希望给 fallback 配上 `url` / `interval`）：

```
实际: ["20000","19999","19998","19999","19998"]
预期: ["20000","19999","19998"]
```

重复项会让 mihomo 对同一个节点做多次健康检查。要绕开必须给每个节点都传一个全新对象、且内部数组也得是拷贝——这既不直观，也无处可查。

## 修改

循环内只累积覆盖层，由 `index.js` 在所有节点都并入之后、编码 `args` 之前统一合并一次：

```js
const configOverride = opts?.config || proxy._config;
if (configOverride) {
    opts._merged.configOverride = {
        ...(opts._merged.configOverride || {}),
        ...configOverride,
    };
}
```

```js
JSON.stringify({
    ...opts._merged.config,
    ...(opts._merged.configOverride || {}),
    "mixed-port": opts.localPort,
})
```

这样既不会让覆盖层中的 `proxy-groups` 成为后续节点的 `push()` 目标，也保留原有的逐 key 浅合并语义：不同节点的非冲突字段会累积，同名字段以后出现的值为准。

非 merge 分支每个节点各自生成完整配置、不存在累积，保持原样未动。

## 测试

新增两个回归测试：

- 共享同一个覆盖层对象时，`GLOBAL.proxies` 中每个节点只出现一次，且 `url` / `interval` 生效。
- 不同节点提供 partial / empty `_config` 时，较早节点的非冲突字段不会丢失。

验证结果：

- 定向测试：**2 passing**
- `pnpm test` 全量：**750 passing**
- `prettier --check` 通过
- `git diff --check` 通过

## 背景

在 Surge Mac 上用 `_merge` + `_mihomoExternal` 时，`GLOBAL` 是 `fallback` 组但没有 `url` / `interval`，坏掉的首个成员要靠流量撞上去才会被剔除，每次请求都先付一次超时。想通过 `_config` 补上健康检查字段时撞到了这个问题。

## Post-Deploy Monitoring & Validation

- Validation window：合并后的首次 SurgeMac merged-config 生成。
- Healthy：`GLOBAL` 没有重复节点，多个 partial `_config` 的非冲突字段均被保留。
- Failure：较早的覆盖字段丢失，或 `GLOBAL` 再次出现重复节点。
- Mitigation：回退本 PR。
- Owner：maintainers。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
