### PR TITLE
feat(sing-box): warn about the dropped certificate fingerprint

### DIFF
--- a/backend/src/core/proxy-utils/producers/sing-box.js
+++ b/backend/src/core/proxy-utils/producers/sing-box.js
@@ -401,7 +401,21 @@ const tlsParser = (proxy, parsedProxy) => {
     if (proxy['_client_key']) parsedProxy.tls.client_key = proxy['_client_key'];
     if (proxy['_client_key_path'])
         parsedProxy.tls.client_key_path = proxy['_client_key_path'];
-    if (!parsedProxy.tls.enabled) delete parsedProxy.tls;
+    if (!parsedProxy.tls.enabled) {
+        delete parsedProxy.tls;
+    } else if (
+        (proxy.fingerprint || proxy['tls-fingerprint']) &&
+        !parsedProxy.tls.reality &&
+        !parsedProxy.tls.certificate &&
+        !parsedProxy.tls.certificate_path &&
+        !parsedProxy.tls.certificate_public_key_sha256
+    ) {
+        // sing-box can only pin the SHA-256 of the certificate public key
+        // https://sing-box.sagernet.org/configuration/shared/tls/#certificate_public_key_sha256
+        $.warn(
+            `Platform sing-box does not support certificate fingerprint pinning, it is dropped for proxy ${proxy.name}. Set _certificate_public_key_sha256 to pin the certificate public key instead`,
+        );
+    }
 };
 
 const sshParser = (proxy = {}) => {

--- a/backend/src/test/proxy-producers/structured.spec.js
+++ b/backend/src/test/proxy-producers/structured.spec.js
@@ -4442,6 +4442,70 @@ describe('Proxy structured producers', function () {
         });
     });
 
+    it('warns about the dropped certificate fingerprint for sing-box', function () {
+        const fingerprint =
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+        const publicKeySha256 = '428F7quaQJvBhEr5TclcjPpsl1ryyNQo7oLBGhhC3UU=';
+        const { result, warnings } = captureWarns(() =>
+            produceInternal('sing-box', [
+                {
+                    type: 'trojan',
+                    name: 'Trojan Pinned',
+                    server: 'trojan.example.com',
+                    port: 443,
+                    password: 'secret',
+                    tls: true,
+                    'tls-fingerprint': fingerprint,
+                },
+                {
+                    type: 'hysteria2',
+                    name: 'Hysteria2 Public Key Pinned',
+                    server: 'hy2.example.com',
+                    port: 443,
+                    password: 'secret',
+                    'tls-fingerprint': fingerprint,
+                    _certificate_public_key_sha256: [publicKeySha256],
+                },
+                {
+                    type: 'vless',
+                    name: 'VLESS Reality Pinned',
+                    server: 'vless.example.com',
+                    port: 443,
+                    uuid: UUID,
+                    tls: true,
+                    'tls-fingerprint': fingerprint,
+                    'reality-opts': {
+                        'public-key': 'pubkey',
+                        'short-id': '08',
+                    },
+                },
+            ]),
+        );
+
+        expect(warnings).to.have.length(1);
+        expect(warnings[0]).to.include('Trojan Pinned');
+        expect(warnings[0]).to.include('_certificate_public_key_sha256');
+        expect(result[0].tls).to.not.have.property(
+            'certificate_public_key_sha256',
+        );
+        expectSubset(result[1], {
+            tls: {
+                enabled: true,
+                certificate_public_key_sha256: [publicKeySha256],
+            },
+        });
+        expectSubset(result[2], {
+            tls: {
+                enabled: true,
+                reality: {
+                    enabled: true,
+                    public_key: 'pubkey',
+                    short_id: '08',
+                },
+            },
+        });
+    });
+
     it('emits WireGuard interface CIDR suffixes for Egern exports', function () {
         const proxies = [
             {


### PR DESCRIPTION
sing-box has no field for the SHA-256 of the certificate itself. The only pin it
accepts is `certificate_public_key_sha256`, the base64 SHA-256 of the public key
(since sing-box 1.13.0), which is why you pointed at `_certificate_public_key_sha256`
as the manual route in #519. What is missing is the signal: the drop is silent, so a
subscription that pinned the certificate becomes an outbound that trusts the system
store, and nothing tells the user.

Same trojan node carrying `tls-fingerprint`, on master 98d2344:

| producer | tls output |
| --- | --- |
| ClashMeta | `"fingerprint":"e3b0c4...b855"` |
| URI | `...&pcs=e3b0c4...b855` |
| sing-box | `{"enabled":true,"server_name":"sni.example.com","insecure":false}` |

Captured `$.warn` / `$.info` / `$.error` for the sing-box run: empty.

The warning fires only when the outbound has nothing else pinning the server: no
`certificate`, no `certificate_path`, no `certificate_public_key_sha256`, no
`reality`. That keeps two paths quiet. First, `ca-str`, where proxy-utils/index.js
derives `tls-fingerprint` from the CA and the certificate is emitted anyway. Second,
the `_certificate_public_key_sha256` workaround, where the pin is already set by hand.

REALITY is excluded because mihomo does not apply `fingerprint` there either: with a
reality config, `StreamTLSConn` goes into `GetRealityConn` and leaves behind the
`tls.Config` that carries the fingerprint verification.

`tls-fingerprint` is filled by the Surge (`server-cert-fingerprint-sha256`), Loon and
QX (`tls-cert-sha256`), URI (`pcs`), hysteria2 URI (`pinSHA256`) and mihomo
(`fingerprint`) parsers, so this covers trojan, hysteria2, tuic, vless and the other
types whose parser calls `tlsParser`.

Related: #519, #287.

Test:

```
cd backend && pnpm test
```

New case: `warns about the dropped certificate fingerprint for sing-box` in
`src/test/proxy-producers/structured.spec.js`. 752 tests pass locally (Node 25.5.0).

One open choice: I used `$.warn`, matching the gecko clamp warning in the same file.
The naive `insecure` drop on line 938 uses `$.info`. Happy to switch to `info` if you
prefer.
