### PR TITLE
fix: reject subscriptions with zero remaining traffic

### DIFF
--- a/backend/src/test/utils/flow.spec.js
+++ b/backend/src/test/utils/flow.spec.js
@@ -6,6 +6,7 @@ import { HEADERS_RESOURCE_CACHE_KEY, SETTINGS_KEY } from '@/constants';
 let $;
 let openApi;
 let getFlowHeaders;
+let validCheck;
 let headersResourceCache;
 let originalRead;
 let originalWrite;
@@ -28,7 +29,7 @@ describe('flow headers requests', function () {
     before(function () {
         ({ default: $ } = require('@/core/app'));
         openApi = require('@/vendor/open-api');
-        ({ getFlowHeaders } = require('@/utils/flow'));
+        ({ getFlowHeaders, validCheck } = require('@/utils/flow'));
         ({ default: headersResourceCache } = require(
             '@/utils/headers-resource-cache'
         ));
@@ -188,5 +189,17 @@ describe('flow headers requests', function () {
             'https://example.com/cached-flow',
         ]);
         expect(maxActiveRequests).to.equal(1);
+    });
+
+    it('throws when remaining traffic is exactly zero', function () {
+        const flow = {
+            total: 100,
+            usage: {
+                upload: 20,
+                download: 80,
+            },
+        };
+
+        expect(() => validCheck(flow)).to.throw('流量已用完');
     });
 });

--- a/backend/src/utils/flow.js
+++ b/backend/src/utils/flow.js
@@ -370,7 +370,7 @@ export function validCheck(flow) {
     if (flow?.total) {
         const upload = flow.usage?.upload || 0;
         const download = flow.usage?.download || 0;
-        if (flow.total - upload - download < 0) {
+        if (flow.total - upload - download <= 0) {
             const current = upload + download;
             const currT = flowTransfer(Math.abs(current));
             currT.value = current < 0 ? '-' + currT.value : currT.value;


### PR DESCRIPTION
Fix `validCheck` so subscriptions with exactly zero remaining traffic are treated as exhausted.

Previously, the validation only rejected negative remaining traffic:

`total - upload - download < 0`

This allowed subscriptions with exactly zero remaining traffic to pass `validCheck`.

This change:
- updates the condition from `< 0` to `<= 0`
- adds a regression test for the zero-remaining-traffic case

Tests:
- `flow.spec.js`: 5 passing
- full test suite: 757 passing

Addresses #551.