### PR TITLE
preserve commas in QX passwords

### DIFF
--- a/backend/src/core/proxy-utils/parsers/peggy/qx.js
+++ b/backend/src/core/proxy-utils/parsers/peggy/qx.js
@@ -188,7 +188,8 @@ port = digits:[0-9]+ {
 }
 
 username = comma "username" equals username:[^,]+ { proxy.username = username.join("").trim(); }
-password = comma "password" equals password:[^,]+ { proxy.password = password.join("").trim(); }
+password = comma "password" equals password:$((!next_parameter .)+) { proxy.password = password.trim(); }
+next_parameter = "," _ [^=,]+ equals
 uuid = comma "password" equals uuid:[^,]+ { proxy.uuid = uuid.join("").trim(); }
 
 method = comma "method" equals cipher:cipher { 

--- a/backend/src/test/proxy-parsers/qx-comma-password.spec.js
+++ b/backend/src/test/proxy-parsers/qx-comma-password.spec.js
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
 import getQxParser from '@/core/proxy-utils/parsers/peggy/qx';
 import QX_Producer from '@/core/proxy-utils/producers/qx';
 

--- a/backend/src/test/proxy-parsers/qx-comma-password.spec.js
+++ b/backend/src/test/proxy-parsers/qx-comma-password.spec.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import getQxParser from '@/core/proxy-utils/parsers/peggy/qx';
+import QX_Producer from '@/core/proxy-utils/producers/qx';
+
+const parser = getQxParser();
+
+describe('QX comma password parsing', function () {
+    const cases = [
+        {
+            name: 'HTTP',
+            input: 'http=127.0.0.1:18080,username=test,password=abc,123,udp-relay=true,tag=HTTP-Comma-Test',
+            tag: 'HTTP-Comma-Test',
+        },
+        {
+            name: 'SOCKS5',
+            input: 'socks5=127.0.0.1:1080,username=test,password=abc,123,udp-relay=true,tag=SOCKS-Comma-Test',
+            tag: 'SOCKS-Comma-Test',
+        },
+        {
+            name: 'Trojan',
+            input: 'trojan=example.com:443,password=abc,123,over-tls=true,tls-verification=false,tag=Trojan-Comma-Test',
+            tag: 'Trojan-Comma-Test',
+        },
+        {
+            name: 'Shadowsocks',
+            input: 'shadowsocks=example.com:443,method=aes-128-gcm,password=abc,123,udp-relay=true,tag=SS-Comma-Test',
+            tag: 'SS-Comma-Test',
+        },
+        {
+            name: 'AnyTLS',
+            input: 'anytls=example.com:443,password=abc,123,over-tls=true,tls-verification=false,tag=AnyTLS-Comma-Test',
+            tag: 'AnyTLS-Comma-Test',
+        },
+    ];
+
+    for (const testCase of cases) {
+        it(`preserves commas inside ${testCase.name} passwords`, function () {
+            const proxy = parser.parse(testCase.input);
+
+            expect(proxy.password).to.equal('abc,123');
+            expect(proxy.name).to.equal(testCase.tag);
+        });
+    }
+
+    it('preserves multiple commas inside a password', function () {
+        const proxy = parser.parse(
+            'http=127.0.0.1:18080,username=test,password=abc,123,456,udp-relay=true,tag=Multi-Comma-Test',
+        );
+
+        expect(proxy.password).to.equal('abc,123,456');
+        expect(proxy.udp).to.equal(true);
+        expect(proxy.name).to.equal('Multi-Comma-Test');
+    });
+
+    it('stops the password before following TLS parameters', function () {
+        const proxy = parser.parse(
+            'http=127.0.0.1:18080,username=test,password=abc,123,over-tls=true,tls-host=example.com,tag=TLS-Test',
+        );
+
+        expect(proxy.password).to.equal('abc,123');
+        expect(proxy.tls).to.equal(true);
+        expect(proxy.sni).to.equal('example.com');
+        expect(proxy.name).to.equal('TLS-Test');
+    });
+
+    it('keeps normal passwords unchanged', function () {
+        const proxy = parser.parse(
+            'http=127.0.0.1:18080,username=test,password=abc123,udp-relay=true,tag=Normal-Test',
+        );
+
+        expect(proxy.password).to.equal('abc123');
+        expect(proxy.name).to.equal('Normal-Test');
+    });
+
+    it('preserves a comma password through QX parse and output', function () {
+        const proxy = parser.parse(
+            'http=127.0.0.1:18080,username=test,password=abc,123,udp-relay=true,tag=Roundtrip-Test',
+        );
+
+        const output = QX_Producer().produce(proxy);
+
+        expect(proxy.password).to.equal('abc,123');
+        expect(output).to.include('password=abc,123');
+        expect(output).to.include('tag=Roundtrip-Test');
+    });
+});


### PR DESCRIPTION
Fix QX proxy parsing when passwords contain commas.
For example, `password=abc,123` works in Quantumult X, but Sub-Store currently stops parsing the password at the first comma and rejects the node.

This affects QX HTTP, SOCKS5, Trojan, Shadowsocks and AnyTLS inputs using the shared password parser.
The parser now keeps commas inside the password and stops when the next `key=value` parameter begins.
Tests cover all five protocols, multiple commas, following parameters, normal passwords and QX parse/output round-trip.