### PR TITLE
feat: add runtime manifest and builtin layer / 添加运行时清单与内建层

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
             ./backend/dist/cron-sync-artifacts.min.js
             ./backend/dist/proxy-utils.esm.mjs
             ./backend/dist/sub-store.bundle.js
+            ./backend/dist/runtime-manifest.json
       - name: Git push assets to "release" branch
         run: |
           cd backend/dist || exit 1

--- a/backend/bundle-esbuild.js
+++ b/backend/bundle-esbuild.js
@@ -1,9 +1,86 @@
 #!/usr/bin/env node
 const fs = require('fs');
+const { parseSync, traverse } = require('@babel/core');
+const { builtinModules } = require('module');
 const path = require('path');
 const { build } = require('esbuild');
 
 const objectHasOwnPolyfill = require.resolve('core-js/actual/object/has-own');
+const builtinModuleNames = new Set(
+    builtinModules.map((name) => name.replace(/^node:/, '')),
+);
+
+function normalizeSpecifier(specifier) {
+    return specifier.replace(/^node:/, '');
+}
+
+function getRequireSpecifiers(content) {
+    const specifiers = new Set();
+
+    traverse(
+        parseSync(content, {
+            babelrc: false,
+            configFile: false,
+            sourceType: 'script',
+        }),
+        {
+            CallExpression({ node }) {
+                if (
+                    node.callee.type === 'Identifier' &&
+                    (node.callee.name === 'require' ||
+                        node.callee.name === '__require') &&
+                    node.arguments.length === 1 &&
+                    node.arguments[0].type === 'StringLiteral'
+                ) {
+                    specifiers.add(node.arguments[0].value);
+                }
+            },
+        },
+    );
+
+    return specifiers;
+}
+
+function getExternalSpecifiers(metafile) {
+    return new Set(
+        Object.values(metafile.outputs).flatMap((output) =>
+            (output.imports || [])
+                .filter((item) => item.external)
+                .map((item) => item.path),
+        ),
+    );
+}
+
+function createRuntimeManifest({ metafile, content }) {
+    const specifiers = new Set([
+        ...getExternalSpecifiers(metafile),
+        ...getRequireSpecifiers(content),
+    ]);
+    const builtins = new Set();
+    const npm = new Set();
+
+    for (const specifier of specifiers) {
+        const normalized = normalizeSpecifier(specifier);
+        if (builtinModuleNames.has(normalized)) {
+            builtins.add(normalized);
+        } else if (!specifier.startsWith('.') && !path.isAbsolute(specifier)) {
+            npm.add(specifier);
+        }
+    }
+
+    return {
+        builtins: [...builtins].sort(),
+        npm: [...npm].sort(),
+        requiresEval: /\beval\s*\(/.test(content),
+        requiresProcessGlobal: /\bprocess\b/.test(content),
+        workerThreads: builtins.has('worker_threads'),
+        childProcess: builtins.has('child_process'),
+        externalBinary: ['shoutrrr'],
+        testedNode: fs
+            .readFileSync(path.join(__dirname, '..', '.node-version'), 'utf8')
+            .trim(),
+    };
+}
 
 !(async () => {
     const version = JSON.parse(
@@ -72,7 +149,7 @@ const objectHasOwnPolyfill = require.resolve('core-js/actual/object/has-own');
         },
     );
 
-    await build({
+    const nodeBuild = await build({
         entryPoints: ['dist/sub-store.no-bundle.js'],
         bundle: true,
         minify: true,
@@ -80,6 +157,7 @@ const objectHasOwnPolyfill = require.resolve('core-js/actual/object/has-own');
         platform: 'node',
         format: 'cjs',
         outfile: 'dist/sub-store.bundle.js',
+        metafile: true,
         // `sub-store.no-bundle.js` comes from `sub-store.min.js`, which already
         // has the Object.hasOwn polyfill injected in the first build stage.
     });
@@ -93,9 +171,22 @@ ${fs.readFileSync(path.join(__dirname, 'dist/sub-store.bundle.js'), {
             encoding: 'utf8',
         },
     );
+    const bundlePath = path.join(__dirname, 'dist/sub-store.bundle.js');
+    fs.writeFileSync(
+        path.join(__dirname, 'dist/runtime-manifest.json'),
+        `${JSON.stringify(
+            createRuntimeManifest({
+                metafile: nodeBuild.metafile,
+                content: fs.readFileSync(bundlePath, 'utf8'),
+            }),
+            null,
+            2,
+        )}\n`,
+    );
 })()
     .catch((e) => {
-        console.log(e);
+        console.error(e);
+        process.exitCode = 1;
     })
     .finally(() => {
         console.log('done');

--- a/backend/bundle-esbuild.js
+++ b/backend/bundle-esbuild.js
@@ -41,19 +41,21 @@ function getRequireSpecifiers(content) {
     return specifiers;
 }
 
-function getExternalSpecifiers(metafile) {
+function getExternalSpecifiers(metafiles) {
     return new Set(
-        Object.values(metafile.outputs).flatMap((output) =>
-            (output.imports || [])
-                .filter((item) => item.external)
-                .map((item) => item.path),
+        metafiles.flatMap((metafile) =>
+            Object.values(metafile.outputs).flatMap((output) =>
+                (output.imports || [])
+                    .filter((item) => item.external)
+                    .map((item) => item.path),
+            ),
         ),
     );
 }
 
-function createRuntimeManifest({ metafile, content }) {
+function createRuntimeManifest({ metafiles, content }) {
     const specifiers = new Set([
-        ...getExternalSpecifiers(metafile),
+        ...getExternalSpecifiers(metafiles),
         ...getRequireSpecifiers(content),
     ]);
     const builtins = new Set();
@@ -82,6 +84,20 @@ function createRuntimeManifest({ metafile, content }) {
     };
 }
 
+const nodeBuiltinExternalPlugin = {
+    name: 'node-builtin-external',
+    setup(build) {
+        build.onResolve({ filter: /.*/ }, (args) => {
+            if (
+                args.path !== 'buffer' &&
+                builtinModuleNames.has(normalizeSpecifier(args.path))
+            ) {
+                return { path: args.path, external: true };
+            }
+        });
+    },
+};
+
 !(async () => {
     const version = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8'),
@@ -100,9 +116,10 @@ function createRuntimeManifest({ metafile, content }) {
         { src: 'src/products/sub-store-0.js', dest: 'dist/sub-store-0.min.js' },
         { src: 'src/products/sub-store-1.js', dest: 'dist/sub-store-1.min.js' },
     ];
+    const browserMetafiles = [];
 
     for await (const artifact of artifacts) {
-        await build({
+        const browserBuild = await build({
             entryPoints: [artifact.src],
             bundle: true,
             minify: true,
@@ -111,7 +128,10 @@ function createRuntimeManifest({ metafile, content }) {
             format: 'iife',
             outfile: artifact.dest,
             inject: [objectHasOwnPolyfill],
+            plugins: [nodeBuiltinExternalPlugin],
+            metafile: true,
         });
+        browserMetafiles.push(browserBuild.metafile);
     }
 
     const browserEsmArtifacts = [
@@ -122,7 +142,7 @@ function createRuntimeManifest({ metafile, content }) {
     ];
 
     for await (const artifact of browserEsmArtifacts) {
-        await build({
+        const browserBuild = await build({
             entryPoints: [artifact.src],
             bundle: true,
             minify: true,
@@ -131,7 +151,10 @@ function createRuntimeManifest({ metafile, content }) {
             format: 'esm',
             outfile: artifact.dest,
             inject: [objectHasOwnPolyfill],
+            plugins: [nodeBuiltinExternalPlugin],
+            metafile: true,
         });
+        browserMetafiles.push(browserBuild.metafile);
     }
 
     let content = fs.readFileSync(path.join(__dirname, 'sub-store.min.js'), {
@@ -176,7 +199,7 @@ ${fs.readFileSync(path.join(__dirname, 'dist/sub-store.bundle.js'), {
         path.join(__dirname, 'dist/runtime-manifest.json'),
         `${JSON.stringify(
             createRuntimeManifest({
-                metafile: nodeBuild.metafile,
+                metafiles: [...browserMetafiles, nodeBuild.metafile],
                 content: fs.readFileSync(bundlePath, 'utf8'),
             }),
             null,

--- a/backend/src/core/proxy-utils/index.js
+++ b/backend/src/core/proxy-utils/index.js
@@ -31,6 +31,7 @@ import { FILES_KEY, MODULES_KEY } from '@/constants';
 import { findByName } from '@/utils/database';
 import { produceArtifact } from '@/restful/sync';
 import { getFlag, removeFlag, getISO, MMDB } from '@/utils/geo';
+import getFs from '@/runtime/fs';
 import Gist from '@/utils/gist';
 import {
     isShadowsocksOverTls,
@@ -352,7 +353,7 @@ async function loadScriptItem(item, executionContext = {}) {
             }
         } else if (url?.startsWith('/')) {
             try {
-                const fs = eval(`require("fs")`);
+                const fs = getFs();
                 script = fs.readFileSync(url.split('#')[0], 'utf8');
                 // $.info(`Script loaded: >>>\n ${script}`);
             } catch (err) {

--- a/backend/src/main.js
+++ b/backend/src/main.js
@@ -12,6 +12,7 @@
  */
 import { version } from '../package.json';
 import $ from '@/core/app';
+import getWorkerThreads from '@/runtime/worker-threads';
 console.log(
     `
 ┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅
@@ -27,7 +28,7 @@ if ($.env.isNode) {
         eval("require('core-js/actual/promise/with-resolvers')");
     }
 
-    const workerThreads = eval("require('node:worker_threads')");
+    const workerThreads = getWorkerThreads();
     if (typeof workerThreads.markAsUncloneable !== 'function') {
         // ponytail: Node < 22 cannot mark web objects uncloneable; remove this fallback when the Android runtime reaches Node 22.
         workerThreads.markAsUncloneable = () => {};

--- a/backend/src/restful/index.js
+++ b/backend/src/restful/index.js
@@ -33,6 +33,8 @@ import registerLogRoutes from './logs';
 import registerAgeRoutes from './age';
 import { consumeShareToken } from './token';
 import { AGE_PUBLIC_KEY } from '@/utils/age';
+import getFs from '@/runtime/fs';
+import getPath from '@/runtime/path';
 
 export function stripBackendPath(url, backendPath) {
     return (backendPath === '/' ? url : url.replace(backendPath, '')) || '/';
@@ -340,8 +342,8 @@ export default function serve() {
                 // 'Asia/Shanghai' // timeZone
             );
         }
-        const path = eval(`require("path")`);
-        const fs = eval(`require("fs")`);
+        const path = getPath();
+        const fs = getFs();
         const data_url = eval('process.env.SUB_STORE_DATA_URL');
         const data_url_post = eval('process.env.SUB_STORE_DATA_URL_POST');
         const fe_be_path = eval('process.env.SUB_STORE_FRONTEND_BACKEND_PATH');

--- a/backend/src/runtime/child-process.js
+++ b/backend/src/runtime/child-process.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getChildProcess() {
+    return tryNodeBuiltin(() => require('child_process'));
+}

--- a/backend/src/runtime/dgram.js
+++ b/backend/src/runtime/dgram.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getDgram() {
+    return tryNodeBuiltin(() => require('dgram'));
+}

--- a/backend/src/runtime/fs.js
+++ b/backend/src/runtime/fs.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getFs() {
+    return tryNodeBuiltin(() => require('fs'));
+}

--- a/backend/src/runtime/net.js
+++ b/backend/src/runtime/net.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getNet() {
+    return tryNodeBuiltin(() => require('net'));
+}

--- a/backend/src/runtime/path.js
+++ b/backend/src/runtime/path.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getPath() {
+    return tryNodeBuiltin(() => require('path'));
+}

--- a/backend/src/runtime/platform.js
+++ b/backend/src/runtime/platform.js
@@ -1,0 +1,11 @@
+import { ENV } from '@/vendor/open-api';
+
+export function tryNodeBuiltin(load) {
+    if (!ENV().isNode) return undefined;
+
+    try {
+        return load();
+    } catch (e) {
+        return undefined;
+    }
+}

--- a/backend/src/runtime/stream-promises.js
+++ b/backend/src/runtime/stream-promises.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getStreamPromises() {
+    return tryNodeBuiltin(() => require('stream/promises'));
+}

--- a/backend/src/runtime/tls.js
+++ b/backend/src/runtime/tls.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getTls() {
+    return tryNodeBuiltin(() => require('tls'));
+}

--- a/backend/src/runtime/worker-threads.js
+++ b/backend/src/runtime/worker-threads.js
@@ -1,0 +1,5 @@
+import { tryNodeBuiltin } from './platform';
+
+export default function getWorkerThreads() {
+    return tryNodeBuiltin(() => require('node:worker_threads'));
+}

--- a/backend/src/test/runtime/browser-bundle.spec.js
+++ b/backend/src/test/runtime/browser-bundle.spec.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const backendPath = path.resolve(__dirname, '../../..');
+
+describe('browser bundle compatibility', function () {
+    this.timeout(10000);
+
+    it('keeps the Buffer polyfill inside browser artifacts', function () {
+        const result = spawnSync(process.execPath, ['bundle-esbuild.js'], {
+            cwd: backendPath,
+            encoding: 'utf8',
+        });
+
+        expect(result.status, result.stderr).to.equal(0);
+
+        for (const artifact of [
+            'sub-store.min.js',
+            'dist/proxy-utils.esm.mjs',
+        ]) {
+            const content = fs.readFileSync(
+                path.join(backendPath, artifact),
+                'utf8',
+            );
+            expect(content).to.not.match(
+                /\b[A-Za-z_$][\w$]*\(\s*['\"]buffer['\"]\)/,
+            );
+            expect(content).to.not.match(/\bfrom\s+['\"]buffer['\"]/);
+        }
+    });
+});

--- a/backend/src/test/runtime/builtin.spec.js
+++ b/backend/src/test/runtime/builtin.spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+
+import getChildProcess from '@/runtime/child-process';
+import getDgram from '@/runtime/dgram';
+import getFs from '@/runtime/fs';
+import getNet from '@/runtime/net';
+import getPath from '@/runtime/path';
+import getStreamPromises from '@/runtime/stream-promises';
+import getTls from '@/runtime/tls';
+import getWorkerThreads from '@/runtime/worker-threads';
+
+describe('runtime builtin getters', function () {
+    it('loads the Node builtins used by the backend', function () {
+        expect(getChildProcess()).to.equal(require('child_process'));
+        expect(getDgram()).to.equal(require('dgram'));
+        expect(getFs()).to.equal(require('fs'));
+        expect(getNet()).to.equal(require('net'));
+        expect(getPath()).to.equal(require('path'));
+        expect(getStreamPromises()).to.equal(require('stream/promises'));
+        expect(getTls()).to.equal(require('tls'));
+        expect(getWorkerThreads()).to.equal(require('node:worker_threads'));
+    });
+});

--- a/backend/src/test/runtime/runtime-manifest.spec.js
+++ b/backend/src/test/runtime/runtime-manifest.spec.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const backendPath = path.resolve(__dirname, '../../..');
+
+function createFixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sub-store-bundle-'));
+    const fixturePath = path.join(root, 'backend');
+
+    fs.mkdirSync(fixturePath);
+    fs.symlinkSync(
+        path.join(backendPath, 'node_modules'),
+        path.join(fixturePath, 'node_modules'),
+        'dir',
+    );
+    fs.symlinkSync(
+        path.join(backendPath, 'src'),
+        path.join(fixturePath, 'src'),
+        'dir',
+    );
+    fs.copyFileSync(
+        path.join(backendPath, 'bundle-esbuild.js'),
+        path.join(fixturePath, 'bundle-esbuild.js'),
+    );
+    fs.copyFileSync(
+        path.join(backendPath, 'package.json'),
+        path.join(fixturePath, 'package.json'),
+    );
+    fs.mkdirSync(path.join(fixturePath, 'dist'));
+
+    return { root, fixturePath };
+}
+
+describe('runtime manifest bundle', function () {
+    this.timeout(10000);
+
+    it('fails when the manifest cannot read the tested Node version', function () {
+        const { root, fixturePath } = createFixture();
+
+        try {
+            const result = spawnSync(process.execPath, ['bundle-esbuild.js'], {
+                cwd: fixturePath,
+                encoding: 'utf8',
+            });
+
+            expect(result.status).to.equal(1);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('excludes require examples inside strings from npm dependencies', function () {
+        const { root, fixturePath } = createFixture();
+
+        try {
+            fs.copyFileSync(
+                path.join(backendPath, '..', '.node-version'),
+                path.join(root, '.node-version'),
+            );
+
+            const result = spawnSync(process.execPath, ['bundle-esbuild.js'], {
+                cwd: fixturePath,
+                encoding: 'utf8',
+            });
+            const manifest = JSON.parse(
+                fs.readFileSync(
+                    path.join(fixturePath, 'dist/runtime-manifest.json'),
+                    'utf8',
+                ),
+            );
+
+            expect(result.status).to.equal(0);
+            expect(manifest.npm).not.to.include('iconv-lite');
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});

--- a/backend/src/utils/dns.js
+++ b/backend/src/utils/dns.js
@@ -1,5 +1,8 @@
 import $ from '@/core/app';
 import dnsPacket from 'dns-packet';
+import getDgram from '@/runtime/dgram';
+import getNet from '@/runtime/net';
+import getTls from '@/runtime/tls';
 import { Buffer } from 'buffer';
 import { isIPv4, isIPv6 } from '@/utils';
 
@@ -155,7 +158,7 @@ export async function doh({
 }
 
 async function queryDnsOverUdp({ server, domain, type = 'A', timeout, edns }) {
-    const dgram = eval("require('dgram')");
+    const dgram = getDgram();
     const buf = buildDnsQuery({
         domain,
         type,
@@ -212,10 +215,7 @@ async function queryDnsOverTcp({
     edns,
     skipCertVerify,
 }) {
-    const transport =
-        server.protocol === 'tls'
-            ? eval("require('tls')")
-            : eval("require('net')");
+    const transport = server.protocol === 'tls' ? getTls() : getNet();
     const transportName = server.protocol === 'tls' ? 'TLS' : 'TCP';
     const payload = buildDnsQuery({
         domain,

--- a/backend/src/utils/download.js
+++ b/backend/src/utils/download.js
@@ -16,6 +16,8 @@ import { produceArtifact } from '@/restful/sync';
 import PROXY_PREPROCESSORS from '@/core/proxy-utils/preprocessors';
 import { ProxyUtils } from '@/core/proxy-utils';
 import { runBackendRequestTask } from '@/utils/request-concurrency';
+import getFs from '@/runtime/fs';
+import getStreamPromises from '@/runtime/stream-promises';
 import {
     AGE_SECRET_KEY,
     decryptArmorIfPresent,
@@ -327,7 +329,7 @@ export default async function download(
         }
     } else if (url?.startsWith('/')) {
         try {
-            const fs = eval(`require("fs")`);
+            const fs = getFs();
             return formatPlainDownloadResult(
                 fs.readFileSync(url.split('#')[0], 'utf8'),
                 returnRaw,
@@ -518,8 +520,8 @@ export default async function download(
 
 export async function downloadFile(url, file) {
     const undici = eval("require('undici')");
-    const fs = eval("require('fs')");
-    const { pipeline } = eval("require('stream/promises')");
+    const fs = getFs();
+    const { pipeline } = getStreamPromises();
     const { Agent, interceptors, request } = undici;
     $.info(`Downloading file...\nURL: ${url}\nFile: ${file}`);
     const { body, statusCode } = await request(url, {

--- a/backend/src/utils/geo.js
+++ b/backend/src/utils/geo.js
@@ -1,4 +1,5 @@
 import $ from '@/core/app';
+import getFs from '@/runtime/fs';
 
 const ISOFlags = {
     '🏳️‍🌈': ['EXP', 'BAND'],
@@ -781,7 +782,7 @@ export class MMDB {
     constructor({ country, asn } = {}) {
         if ($.env.isNode) {
             const Reader = eval(`require("@maxmind/geoip2-node")`).Reader;
-            const fs = eval("require('fs')");
+            const fs = getFs();
             const countryFile =
                 country || eval('process.env.SUB_STORE_MMDB_COUNTRY_PATH');
             const asnFile = asn || eval('process.env.SUB_STORE_MMDB_ASN_PATH');

--- a/backend/src/vendor/open-api.js
+++ b/backend/src/vendor/open-api.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-undef */
 import { installConsoleLogCapture } from '@/utils/debug-logs';
+import getChildProcess from '@/runtime/child-process';
+import getFs from '@/runtime/fs';
 
 const isQX = typeof $task !== 'undefined';
 const isLoon = typeof $loon !== 'undefined';
@@ -78,7 +80,7 @@ export class OpenAPI {
         }
         this.node = (() => {
             if (isNode) {
-                const fs = eval("require('fs')");
+                const fs = getFs();
 
                 return {
                     fs,
@@ -332,7 +334,7 @@ export class OpenAPI {
                             );
                         });
                 } else {
-                    const { execFile } = eval(`require("child_process")`);
+                    const { execFile } = getChildProcess();
                     execFile(
                         'shoutrrr',
                         [


### PR DESCRIPTION
## Summary / 概要

Release artifacts now state the Node runtime surface they require, so hosts can inspect compatibility before startup. Runtime builtin access remains lazy and browser bundles keep their existing dependency behavior.

---

Release 附件现在声明所需的 Node 运行时依赖面，宿主可在启动前检查兼容性。builtin 访问仍保持惰性，浏览器 bundle 保持既有依赖行为。

## Compatibility / 兼容性

The manifest is generated from the final bundle and released with it. It records builtins, npm dependencies, runtime capabilities, and the tested Node version.

The backend uses a small builtin layer for Node-only modules. Non-builtin lazy `eval(require(...))` paths and the two-stage build remain unchanged.

---

清单由最终 bundle 生成并随 Release 发布，记录 builtin、npm 依赖、运行时能力及测试 Node 版本。

后端通过轻量 builtin 层访问仅 Node 可用的模块；非 builtin 的惰性 `eval(require(...))` 路径及双段构建机制保持不变。

## Validation / 验证

- `pnpm bundle:esbuild`
- Node `24.15.0`: `pnpm test` (`778 passing`)
- Fresh Node `24.20.0` run: `node bundle-esbuild.js` and the full test suite (`778 passing`)
- `git diff --check`
- Docker smoke validation: backend API, frontend static assets, and subscription download

---

- `pnpm bundle:esbuild`
- Node `24.15.0`：`pnpm test`（`778 passing`）
- 新鲜 Node `24.20.0` 验证：`node bundle-esbuild.js` 及完整测试（`778 passing`）
- `git diff --check`
- Docker 冒烟：后端 API、前端静态资源及订阅下载
