### PR TITLE
feat: Egern 输出支持 shadowsocksr

### DIFF
--- a/backend/src/core/proxy-utils/producers/egern.js
+++ b/backend/src/core/proxy-utils/producers/egern.js
@@ -18,6 +18,7 @@ export default function Egern_Producer() {
                         'https',
                         'socks5',
                         'ss',
+                        'ssr',
                         'trojan',
                         'hysteria2',
                         'vless',
@@ -91,6 +92,8 @@ export default function Egern_Producer() {
                     proxy.type === 'snell' &&
                     normalizeSnellVersion(proxy.version) === null
                 ) {
+                    return false;
+                } else if (proxy.type === 'ssr' && !isEgernSsr(proxy)) {
                     return false;
                 } else if (
                     ['anytls'].includes(proxy.type) &&
@@ -208,6 +211,21 @@ export default function Egern_Producer() {
                                 );
                             }
                         }
+                    } else if (proxy.type === 'ssr') {
+                        proxy = {
+                            type: 'shadowsocksr',
+                            name: proxy.name,
+                            method: normalizeSsrMethod(proxy.cipher),
+                            server: proxy.server,
+                            port: proxy.port,
+                            password: proxy.password,
+                            protocol: normalizeSsrPlugin(proxy.protocol),
+                            protocol_param: proxy['protocol-param'],
+                            obfs: normalizeSsrPlugin(proxy.obfs),
+                            obfs_param: proxy['obfs-param'],
+                            tfo: getTfo(proxy),
+                            udp_relay: getUdpRelay(proxy),
+                        };
                     } else if (proxy.type === 'hysteria2') {
                         proxy = {
                             type: 'hysteria2',
@@ -542,6 +560,7 @@ export default function Egern_Producer() {
                             'https',
                             'socks5',
                             'ss',
+                            'ssr',
                             'trojan',
                             'vless',
                             'vmess',
@@ -578,6 +597,7 @@ export default function Egern_Producer() {
                         [
                             'socks5',
                             'ss',
+                            'ssr',
                             'trojan',
                             'vless',
                             'vmess',
@@ -604,7 +624,7 @@ export default function Egern_Producer() {
                         }
                     }
                     if (
-                        ['ss'].includes(original.type) &&
+                        ['ss', 'ssr'].includes(original.type) &&
                         proxy.shadow_tls &&
                         original['udp-port'] > 0 &&
                         original['udp-port'] <= 65535
@@ -725,6 +745,66 @@ function normalizeSnellVersion(version) {
     if (!/^[1-5]$/.test(normalized)) return null;
 
     return parseInt(normalized, 10);
+}
+
+// Egern 的 shadowsocksr 只支持流加密，protocol / obfs 沿用 SSR 上游插件名。
+const EGERN_SSR_METHODS = [
+    'none',
+    'dummy',
+    'rc4-md5',
+    'aes-128-cfb',
+    'aes-192-cfb',
+    'aes-256-cfb',
+    'aes-128-ctr',
+    'aes-192-ctr',
+    'aes-256-ctr',
+    'chacha20',
+    'chacha20-ietf',
+    'xchacha20',
+];
+
+const EGERN_SSR_PROTOCOLS = [
+    'origin',
+    'auth_sha1_v4',
+    'auth_aes128_md5',
+    'auth_aes128_sha1',
+    'auth_chain_a',
+    'auth_chain_b',
+];
+
+const EGERN_SSR_OBFS = [
+    'plain',
+    'http_simple',
+    'http_post',
+    'random_head',
+    'tls1.2_ticket_auth',
+    'tls1.2_ticket_fastauth',
+];
+
+function normalizeSsrPlugin(value) {
+    if (value == null) return undefined;
+
+    const normalized = `${value}`.trim().toLowerCase();
+    return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeSsrMethod(cipher) {
+    const method = normalizeSsrPlugin(cipher);
+    // Egern 的空加密写作 none / dummy
+    return method === 'plain' ? 'none' : method;
+}
+
+function isEgernSsr(proxy) {
+    if (!EGERN_SSR_METHODS.includes(normalizeSsrMethod(proxy.cipher))) {
+        return false;
+    }
+    // protocol / obfs 留空时由 Egern 补 origin / plain
+    const protocol = normalizeSsrPlugin(proxy.protocol);
+    if (protocol != null && !EGERN_SSR_PROTOCOLS.includes(protocol)) {
+        return false;
+    }
+    const obfs = normalizeSsrPlugin(proxy.obfs);
+    return obfs == null || EGERN_SSR_OBFS.includes(obfs);
 }
 
 function getFirstHeaderValue(headers, ...keys) {

--- a/backend/src/test/proxy-producers/structured.spec.js
+++ b/backend/src/test/proxy-producers/structured.spec.js
@@ -2804,6 +2804,136 @@ describe('Proxy structured producers', function () {
         });
     });
 
+    it('emits Egern shadowsocksr nodes with plugin params and shadow-tls', function () {
+        const proxies = [
+            {
+                type: 'ssr',
+                name: 'Egern SSR Full',
+                server: 'ssr.example.com',
+                port: 8388,
+                cipher: 'AES-128-CFB',
+                password: 'secret',
+                protocol: 'auth_aes128_md5',
+                'protocol-param': '64:Xxxxx',
+                obfs: 'tls1.2_ticket_auth',
+                'obfs-param': 'www.bing.com',
+                udp: true,
+                tfo: true,
+                'block-quic': 'on',
+                'udp-port': 8389,
+                plugin: 'shadow-tls',
+                'plugin-opts': {
+                    host: 'mask.example.com',
+                    password: 'shadow-pass',
+                    version: 3,
+                },
+            },
+            {
+                type: 'ssr',
+                name: 'Egern SSR Min',
+                server: 'ssr2.example.com',
+                port: 443,
+                cipher: 'plain',
+                password: 'secret',
+            },
+        ];
+
+        const internal = produceInternal('Egern', proxies);
+        const external = loadProducedYaml('Egern', proxies);
+
+        for (const output of [internal, external.proxies]) {
+            expect(output).to.have.length(2);
+            expectSubset(output[0], {
+                shadowsocksr: {
+                    name: 'Egern SSR Full',
+                    server: 'ssr.example.com',
+                    port: 8388,
+                    method: 'aes-128-cfb',
+                    password: 'secret',
+                    protocol: 'auth_aes128_md5',
+                    protocol_param: '64:Xxxxx',
+                    obfs: 'tls1.2_ticket_auth',
+                    obfs_param: 'www.bing.com',
+                    tfo: true,
+                    udp_relay: true,
+                    block_quic: true,
+                    udp_port: 8389,
+                    shadow_tls: {
+                        password: 'shadow-pass',
+                        sni: 'mask.example.com',
+                    },
+                },
+            });
+            // 空加密统一写成 none；protocol / obfs 留空交给 Egern 补 origin / plain
+            expectSubset(output[1], {
+                shadowsocksr: {
+                    name: 'Egern SSR Min',
+                    method: 'none',
+                },
+            });
+        }
+        expect(external.proxies[1].shadowsocksr).to.not.have.property(
+            'protocol',
+        );
+        expect(external.proxies[1].shadowsocksr).to.not.have.property('obfs');
+    });
+
+    it('skips Egern shadowsocksr with unsupported cipher or plugins', function () {
+        const proxies = [
+            {
+                type: 'ssr',
+                name: 'SSR AEAD',
+                server: 'ssr.example.com',
+                port: 8388,
+                cipher: 'aes-128-gcm',
+                password: 'secret',
+            },
+            {
+                type: 'ssr',
+                name: 'SSR Unknown Protocol',
+                server: 'ssr.example.com',
+                port: 8388,
+                cipher: 'aes-128-cfb',
+                password: 'secret',
+                protocol: 'auth_chain_c',
+            },
+            {
+                type: 'ssr',
+                name: 'SSR Unknown Obfs',
+                server: 'ssr.example.com',
+                port: 8388,
+                cipher: 'aes-128-cfb',
+                password: 'secret',
+                obfs: 'tls1.0_session_auth',
+            },
+            {
+                type: 'ssr',
+                name: 'SSR Healthy',
+                server: 'ssr.example.com',
+                port: 8388,
+                cipher: 'chacha20-ietf',
+                password: 'secret',
+                protocol: 'auth_chain_a',
+                obfs: 'http_simple',
+            },
+        ];
+
+        const internal = produceInternal('Egern', proxies);
+        const external = loadProducedYaml('Egern', proxies);
+
+        for (const output of [internal, external.proxies]) {
+            expect(output).to.have.length(1);
+            expectSubset(output[0], {
+                shadowsocksr: {
+                    name: 'SSR Healthy',
+                    method: 'chacha20-ietf',
+                    protocol: 'auth_chain_a',
+                    obfs: 'http_simple',
+                },
+            });
+        }
+    });
+
     it('emits Egern SSH nodes with auth, host keys, flags, and shadow-tls', function () {
         const proxies = [
             {


### PR DESCRIPTION
## 变更

`ssr` 节点此前会被 Egern producer 整条过滤掉，现在映射为 Egern 的 `shadowsocksr`。

字段映射：

| 内部字段 | Egern |
| --- | --- |
| `cipher` | `method` |
| `protocol-param` | `protocol_param` |
| `obfs-param` | `obfs_param` |

同时接上已有的 `shadow_tls`、`block_quic`、`udp_port` 处理（`udp_port` 沿用 `ss` 的条件，仅在存在 shadow-tls 时输出 —— ShadowTLS 只包 TCP，UDP 才需要另开端口）。

## 过滤

Egern 的 SSR 仅支持流加密，protocol / obfs 取 SSR 上游插件名，因此按其支持范围过滤，避免产出无法连接的节点：

- **method**：`none`/`dummy`、`rc4-md5`、`aes-{128,192,256}-cfb`、`aes-{128,192,256}-ctr`、`chacha20`、`chacha20-ietf`、`xchacha20`（AEAD 及 `bf-cfb` 等一律跳过）
- **protocol**：`origin`、`auth_sha1_v4`、`auth_aes128_md5`、`auth_aes128_sha1`、`auth_chain_a`、`auth_chain_b`
- **obfs**：`plain`、`http_simple`、`http_post`、`random_head`、`tls1.2_ticket_auth`、`tls1.2_ticket_fastauth`

`protocol` / `obfs` 留空时不输出，交由 Egern 补 `origin` / `plain`；`plain` 加密归一成 `none`。

## 测试

新增 2 个用例，覆盖完整字段映射 + shadow-tls，以及不支持的 cipher / protocol / obfs 被跳过。全量测试 776 passing，prettier 通过。
