### PR TITLE
fix: filter masque-surge for ClashMeta

### DIFF
--- a/backend/src/core/proxy-utils/producers/clashmeta.js
+++ b/backend/src/core/proxy-utils/producers/clashmeta.js
@@ -62,6 +62,12 @@ export default function ClashMeta_Producer() {
                     );
                     return false;
                 }
+                if (proxy.type === 'masque-surge') {
+                    $.error(
+                        `mihomo does not support Surge MASQUE proxy type. Proxy ${proxy.name} has been filtered.`,
+                    );
+                    return false;
+                }
                 if (hasRootHeaders(proxy) && proxy.type === 'trusttunnel') {
                     $.error(
                         `mihomo does not support headers for TrustTunnel proxy ${proxy.name}. Proxy has been filtered.`,


### PR DESCRIPTION
Surge MASQUE nodes are stored as `masque-surge`. The ClashMeta producer passes them through unchanged, and mihomo refuses to start: `Parse config error: proxy 1: unsupport proxy type: masque-surge` — the whole config is rejected, not just that node.

Filtered it the same way as h2-connect.